### PR TITLE
feat: add PR check status and merge readiness to status bar

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -4,6 +4,9 @@ mod pr;
 mod status;
 mod worktree;
 
-pub use pr::{PrManager, PrPreflightResult, PrState, PrStatus};
+pub use pr::{
+    CheckState, CheckStatus, MergeReadiness, MergeableStatus, PrManager, PrPreflightResult,
+    PrState, PrStatus, ReviewDecision,
+};
 pub use status::GitDiffStats;
 pub use worktree::{WorktreeInfo, WorktreeManager};


### PR DESCRIPTION
## Summary
- Extend PR detection to fetch CI check status, merge conflict state, and review decision from GitHub via `gh pr view --json`
- Display check status indicators (✓ passing, ⋯ pending, N failing) after PR badge
- Show "conflicts" warning when merge conflicts are detected
- Color PR badge based on merge readiness: green (ready), gray (blocked), red (conflicts)

## Test plan
- [ ] Create a PR with passing checks - verify green badge with ✓
- [ ] Create a PR with pending checks - verify ⋯ indicator
- [ ] Create a PR with failing checks - verify red "N failing" text
- [ ] Create a PR with merge conflicts - verify red "conflicts" text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced pull request status display with CI check indicators (✓ passing, ⋯ pending, ✗ failing)
  * Added merge readiness tracking showing conflict detection and review status
  * Improved PR badge with comprehensive status information including check state and merge readiness

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->