### PR TITLE
feat: change default theme to Dracula

### DIFF
--- a/src/ui/components/theme/builtin.rs
+++ b/src/ui/components/theme/builtin.rs
@@ -21,7 +21,7 @@ pub fn builtin_themes() -> Vec<(&'static str, Theme)> {
 /// Get a built-in theme by name.
 pub fn get_builtin(name: &str) -> Option<Theme> {
     match name {
-        "default" => Some(Theme::default_dark()),
+        "default" => Some(dracula()),
         "default-dark" => Some(Theme::default_dark()),
         "default-light" => Some(Theme::default_light()),
         "catppuccin-mocha" => Some(catppuccin_mocha()),

--- a/src/ui/components/theme/types.rs
+++ b/src/ui/components/theme/types.rs
@@ -144,7 +144,7 @@ pub struct Theme {
 
 impl Default for Theme {
     fn default() -> Self {
-        Self::default_dark()
+        super::builtin::dracula()
     }
 }
 


### PR DESCRIPTION
## Summary
- Changes the default application theme from default-dark to Dracula
- Updates both the `Theme::default()` implementation and the `get_builtin("default")` fallback

## Test plan
- [ ] Launch the app without a theme configured and verify Dracula theme is applied
- [ ] Verify explicitly selecting other themes still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added theme system with built-in themes and support for VS Code extension themes
  * Added theme picker UI for easy theme discovery and selection
  * Added theme configuration persistence to config file
  * Implemented contrast-aware color adjustments for improved visual accessibility

* **Chores**
  * Added json5 and parking_lot dependencies for theme management

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->