### PR TITLE
feat: save input to history when Ctrl+C clears prompt

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -854,9 +854,14 @@ impl App {
             self.state.should_quit = true;
             effects.push(Effect::SaveSessionState);
         } else {
-            // First press while idle: clear input + show warning
-            tracing::debug!("Ctrl+C: first press while idle, clearing input and showing warning");
+            // First press while idle: save to history + clear input + show warning
+            tracing::debug!("Ctrl+C: first press while idle, saving to history, clearing input and showing warning");
             if let Some(session) = self.state.tab_manager.active_session_mut() {
+                // Save current input to history before clearing (if non-empty)
+                let current_input = session.input_box.input().to_string();
+                if !current_input.trim().is_empty() {
+                    session.input_box.add_to_history(current_input);
+                }
                 session.input_box.clear();
             }
             self.state.footer_message = Some("Press Ctrl+C again to quit".into());

--- a/src/ui/components/input_box.rs
+++ b/src/ui/components/input_box.rs
@@ -108,6 +108,29 @@ impl InputBox {
         self.clear_selection();
     }
 
+    /// Add text to history without submitting.
+    /// Expands pending pastes and removes image placeholders to match submit() behavior.
+    pub fn add_to_history(&mut self, text: String) {
+        // Expand any pending large pastes
+        let mut expanded = text;
+        for (placeholder, actual) in &self.pending_pastes {
+            if expanded.contains(placeholder) {
+                expanded = expanded.replace(placeholder, actual);
+            }
+        }
+
+        // Remove image placeholders since the images won't be submitted
+        for img in &self.attached_images {
+            expanded = expanded.replace(&img.placeholder, "");
+        }
+
+        // Only add non-whitespace entries (matches submit() behavior)
+        let trimmed = expanded.trim();
+        if !trimmed.is_empty() {
+            self.history.push(trimmed.to_string());
+        }
+    }
+
     /// Submit input and add to history
     pub fn submit(&mut self) -> InputSubmit {
         let input = std::mem::take(&mut self.input);


### PR DESCRIPTION
## Summary
- Save current input text to history before clearing on first Ctrl+C press
- Users can retrieve cancelled text by pressing Arrow Up

## Test plan
- Type text in input box, press Ctrl+C, verify input clears and warning shows
- Press Arrow Up, verify the cancelled text appears in the input box

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pressing Ctrl+C while idle now saves your current input to session history before clearing it, preventing accidental loss of unsent messages.
  * Saved entries clean up pending paste placeholders and remove attachment placeholders so history contains the final text users expect.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->