### PR TITLE
Fix copy spacing for wrapped chat lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 
 [[package]]
 name = "conduit"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "ansi-to-tui",
  "anyhow",


### PR DESCRIPTION
Capture whitespace at wrap breaks so copied selections preserve spaces. Adds a regression test for joiner behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text wrapping to correctly preserve original whitespace spacing at line breaks.

* **Tests**
  * Added test coverage for text wrapping whitespace handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->