### PR TITLE
feat: add chat jump to user messages

### DIFF
--- a/src/config/config.toml.example
+++ b/src/config/config.toml.example
@@ -134,6 +134,8 @@
 # scroll_page_up = "<PgUp>"
 # scroll_page_down = "<PgDn>"
 # scroll_to_bottom = "<Esc>"
+# prev_user_message = "M-<Up>"
+# next_user_message = "M-<Down>"
 # next_tab = "<Tab>"
 # prev_tab = "S-<Tab>"
 

--- a/src/config/default_keys.rs
+++ b/src/config/default_keys.rs
@@ -181,6 +181,8 @@ pub fn default_keybindings() -> KeybindingConfig {
         KeyCombo::new(KeyCode::Esc, KeyModifiers::NONE),
         Action::ScrollToBottom,
     );
+    bind(chat, "M-<Up>", Action::ScrollPrevUserMessage);
+    bind(chat, "M-<Down>", Action::ScrollNextUserMessage);
 
     // Tab toggles Plan/Build mode
     chat.insert(

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -331,6 +331,8 @@ pub fn parse_action(name: &str) -> Option<Action> {
         "scroll_page_down" => Some(Action::ScrollPageDown),
         "scroll_to_top" => Some(Action::ScrollToTop),
         "scroll_to_bottom" => Some(Action::ScrollToBottom),
+        "prev_user_message" => Some(Action::ScrollPrevUserMessage),
+        "next_user_message" => Some(Action::ScrollNextUserMessage),
 
         // Input editing
         "insert_newline" => Some(Action::InsertNewline),
@@ -436,6 +438,8 @@ pub const COMMAND_NAMES: &[&str] = &[
     "scroll_page_down",
     "scroll_to_top",
     "scroll_to_bottom",
+    "prev_user_message",
+    "next_user_message",
     // Input editing
     "insert_newline",
     "backspace",

--- a/src/ui/action.rs
+++ b/src/ui/action.rs
@@ -64,6 +64,10 @@ pub enum Action {
     ScrollToTop,
     /// Scroll to bottom of chat
     ScrollToBottom,
+    /// Jump to previous user message in chat
+    ScrollPrevUserMessage,
+    /// Jump to next user message in chat
+    ScrollNextUserMessage,
 
     // ========== Input Box Editing ==========
     /// Insert a newline (for multi-line input)
@@ -248,6 +252,8 @@ impl Action {
             Action::ScrollPageDown => "Page down",
             Action::ScrollToTop => "Scroll to top",
             Action::ScrollToBottom => "Scroll to bottom",
+            Action::ScrollPrevUserMessage => "Previous user message",
+            Action::ScrollNextUserMessage => "Next user message",
 
             // Input editing
             Action::InsertNewline => "Insert newline",

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1928,6 +1928,64 @@ impl App {
                     session.chat_view.scroll_to_bottom();
                 }
             }
+            Action::ScrollPrevUserMessage => {
+                if let (Some(session), Some(chat_area)) = (
+                    self.state.tab_manager.active_session_mut(),
+                    self.state.chat_area,
+                ) {
+                    if let Some(content) =
+                        crate::ui::components::ChatView::content_area_for(chat_area)
+                    {
+                        let mut extra_len = 0usize;
+                        if session.is_processing {
+                            extra_len += 1;
+                        }
+                        if let Some(queue_lines) =
+                            Self::build_queue_lines(session, chat_area.width, self.state.input_mode)
+                        {
+                            extra_len += queue_lines.len();
+                        }
+                        if extra_len > 0 {
+                            extra_len += 1; // spacing line after extras
+                        }
+
+                        session.chat_view.scroll_to_prev_user_message(
+                            content.width,
+                            content.height as usize,
+                            extra_len,
+                        );
+                    }
+                }
+            }
+            Action::ScrollNextUserMessage => {
+                if let (Some(session), Some(chat_area)) = (
+                    self.state.tab_manager.active_session_mut(),
+                    self.state.chat_area,
+                ) {
+                    if let Some(content) =
+                        crate::ui::components::ChatView::content_area_for(chat_area)
+                    {
+                        let mut extra_len = 0usize;
+                        if session.is_processing {
+                            extra_len += 1;
+                        }
+                        if let Some(queue_lines) =
+                            Self::build_queue_lines(session, chat_area.width, self.state.input_mode)
+                        {
+                            extra_len += queue_lines.len();
+                        }
+                        if extra_len > 0 {
+                            extra_len += 1; // spacing line after extras
+                        }
+
+                        session.chat_view.scroll_to_next_user_message(
+                            content.width,
+                            content.height as usize,
+                            extra_len,
+                        );
+                    }
+                }
+            }
 
             // ========== Input Box Editing ==========
             Action::InsertNewline => {

--- a/src/ui/components/chat_view/chat_view_cache.rs
+++ b/src/ui/components/chat_view/chat_view_cache.rs
@@ -189,7 +189,7 @@ impl ChatView {
 }
 
 /// Check if a line is blank (empty or only whitespace)
-fn is_blank_line(line: &Line<'_>) -> bool {
+pub(super) fn is_blank_line(line: &Line<'_>) -> bool {
     if line.spans.is_empty() {
         return true;
     }


### PR DESCRIPTION
Bind alt+up/down and wire scroll targets for user message navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcuts to navigate between user messages in chat. Use Meta+Up Arrow to jump to the previous user message and Meta+Down Arrow to jump to the next user message. These new bindings provide efficient message navigation, allowing quick review of conversation history.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->