### PR TITLE
fix: show detached branch label

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -6935,7 +6935,7 @@ Acknowledge that you have received this context by replying ONLY with the single
                         session.status_bar.set_branch_name(branch.clone());
                     }
                 }
-                // Always update sidebar data (including None for detached HEAD)
+                // Always update sidebar data (including detached indicator)
                 self.state
                     .sidebar_data
                     .update_workspace_branch(workspace_id, branch);


### PR DESCRIPTION
Show '(detached)' in the status bar and sidebar when HEAD is detached, and add unit tests for branch detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved git branch detection to properly indicate when the repository HEAD is in a detached state, providing clearer status information to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->