### PR TITLE
feat: ingest CodeRabbit feedback rounds

### DIFF
--- a/src/coderabbit/mod.rs
+++ b/src/coderabbit/mod.rs
@@ -978,7 +978,7 @@ fn find_section_blocks<'a>(body: &'a str, label: &str) -> Vec<&'a str> {
     blocks
 }
 
-fn extract_details_block<'a>(body: &'a str, start: usize) -> Option<(&'a str, usize)> {
+fn extract_details_block(body: &str, start: usize) -> Option<(&str, usize)> {
     let mut idx = start;
     let mut depth = 0i64;
     while idx < body.len() {

--- a/src/coderabbit/mod.rs
+++ b/src/coderabbit/mod.rs
@@ -115,7 +115,7 @@ fn check_run_key(check: &PrStatusCheck) -> Option<&str> {
     check
         .started_at
         .as_deref()
-        .or_else(|| check.completed_at.as_deref())
+        .or(check.completed_at.as_deref())
 }
 
 fn check_state_from_status(check: &PrStatusCheck) -> CodeRabbitCheckState {

--- a/src/coderabbit/mod.rs
+++ b/src/coderabbit/mod.rs
@@ -1,0 +1,737 @@
+use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, Duration, Utc};
+use serde::de::DeserializeOwned;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use uuid::Uuid;
+
+use crate::data::{
+    CodeRabbitCategory, CodeRabbitItem, CodeRabbitItemSource, CodeRabbitItemStore, CodeRabbitMode,
+    CodeRabbitRound, CodeRabbitRoundStatus, CodeRabbitRoundStore, CodeRabbitSeverity,
+    RepositorySettings, RepositorySettingsStore, RepositoryStore, WorkspaceStore,
+};
+use crate::git::{PrStatus, PrStatusCheck};
+
+const CODERABBIT_CONTEXT: &str = "CodeRabbit";
+const CODERABBIT_LOGINS: [&str; 2] = ["coderabbitai[bot]", "coderabbitai"];
+const CODERABBIT_WINDOW_SLACK_MINUTES: i64 = 10;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodeRabbitCheckState {
+    Pending,
+    Success,
+    Failure,
+    Error,
+    Cancelled,
+    Skipped,
+    Unknown,
+}
+
+impl CodeRabbitCheckState {
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            CodeRabbitCheckState::Success
+                | CodeRabbitCheckState::Failure
+                | CodeRabbitCheckState::Error
+                | CodeRabbitCheckState::Cancelled
+                | CodeRabbitCheckState::Skipped
+        )
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CodeRabbitCheckState::Pending => "pending",
+            CodeRabbitCheckState::Success => "success",
+            CodeRabbitCheckState::Failure => "failure",
+            CodeRabbitCheckState::Error => "error",
+            CodeRabbitCheckState::Cancelled => "cancelled",
+            CodeRabbitCheckState::Skipped => "skipped",
+            CodeRabbitCheckState::Unknown => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CodeRabbitCompletion {
+    pub pr_number: u32,
+    pub head_sha: String,
+    pub check_state: CodeRabbitCheckState,
+    pub check_started_at: Option<String>,
+}
+
+pub fn detect_completion(old: Option<&PrStatus>, new: &PrStatus) -> Option<CodeRabbitCompletion> {
+    let pr_number = new.number?;
+    let head_sha = new.head_sha.clone()?;
+    let new_check = find_coderabbit_check(&new.status_checks)?;
+    let new_state = check_state_from_status(new_check);
+    if !new_state.is_terminal() {
+        return None;
+    }
+
+    let old_state = old
+        .and_then(|status| find_coderabbit_check(&status.status_checks))
+        .map(check_state_from_status);
+    let started_at = new_check.started_at.clone();
+
+    if let (Some(old_status), Some(old_check)) = (
+        old_state,
+        old.and_then(|status| find_coderabbit_check(&status.status_checks)),
+    ) {
+        let same_started_at = started_at.as_deref() == old_check.started_at.as_deref();
+        if old_status.is_terminal() && old_status == new_state && same_started_at {
+            return None;
+        }
+    }
+
+    Some(CodeRabbitCompletion {
+        pr_number,
+        head_sha,
+        check_state: new_state,
+        check_started_at: started_at,
+    })
+}
+
+fn find_coderabbit_check(checks: &[PrStatusCheck]) -> Option<&PrStatusCheck> {
+    checks.iter().find(|check| {
+        check
+            .context
+            .as_deref()
+            .map(|value| value == CODERABBIT_CONTEXT)
+            .unwrap_or(false)
+            || check
+                .name
+                .as_deref()
+                .map(|value| value == CODERABBIT_CONTEXT)
+                .unwrap_or(false)
+    })
+}
+
+fn check_state_from_status(check: &PrStatusCheck) -> CodeRabbitCheckState {
+    if let Some(state) = check.state.as_deref() {
+        return match state.to_ascii_uppercase().as_str() {
+            "SUCCESS" => CodeRabbitCheckState::Success,
+            "FAILURE" => CodeRabbitCheckState::Failure,
+            "ERROR" => CodeRabbitCheckState::Error,
+            "PENDING" | "EXPECTED" => CodeRabbitCheckState::Pending,
+            _ => CodeRabbitCheckState::Unknown,
+        };
+    }
+
+    let status = check.status.as_deref().unwrap_or("").to_ascii_uppercase();
+    if status != "COMPLETED" {
+        return CodeRabbitCheckState::Pending;
+    }
+    match check
+        .conclusion
+        .as_deref()
+        .unwrap_or("")
+        .to_ascii_uppercase()
+        .as_str()
+    {
+        "SUCCESS" | "NEUTRAL" => CodeRabbitCheckState::Success,
+        "FAILURE" | "TIMED_OUT" | "ACTION_REQUIRED" => CodeRabbitCheckState::Failure,
+        "CANCELLED" => CodeRabbitCheckState::Cancelled,
+        "SKIPPED" => CodeRabbitCheckState::Skipped,
+        _ => CodeRabbitCheckState::Unknown,
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CodeRabbitItemDraft {
+    pub comment_id: i64,
+    pub source: CodeRabbitItemSource,
+    pub category: CodeRabbitCategory,
+    pub severity: Option<CodeRabbitSeverity>,
+    pub file_path: Option<String>,
+    pub line: Option<i64>,
+    pub original_line: Option<i64>,
+    pub diff_hunk: Option<String>,
+    pub html_url: String,
+    pub body: String,
+    pub agent_prompt: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Clone)]
+pub struct CodeRabbitProcessor {
+    repo_store: RepositoryStore,
+    workspace_store: WorkspaceStore,
+    settings_store: RepositorySettingsStore,
+    round_store: CodeRabbitRoundStore,
+    item_store: CodeRabbitItemStore,
+}
+
+impl CodeRabbitProcessor {
+    pub fn new(
+        repo_store: RepositoryStore,
+        workspace_store: WorkspaceStore,
+        settings_store: RepositorySettingsStore,
+        round_store: CodeRabbitRoundStore,
+        item_store: CodeRabbitItemStore,
+    ) -> Self {
+        Self {
+            repo_store,
+            workspace_store,
+            settings_store,
+            round_store,
+            item_store,
+        }
+    }
+
+    pub fn handle_completion(
+        &self,
+        workspace_id: Uuid,
+        completion: CodeRabbitCompletion,
+    ) -> Result<()> {
+        let workspace = self
+            .workspace_store
+            .get_by_id(workspace_id)
+            .context("Load workspace for CodeRabbit completion")?
+            .ok_or_else(|| anyhow!("Workspace not found for CodeRabbit completion"))?;
+        let repo_id = workspace.repository_id;
+        let settings = self
+            .settings_store
+            .get_or_default(repo_id)
+            .context("Load repository settings for CodeRabbit")?;
+        if settings.coderabbit_mode == CodeRabbitMode::Disabled {
+            return Ok(());
+        }
+
+        let observed_at = Utc::now();
+        let check_started_at =
+            parse_timestamp(completion.check_started_at.as_deref()).unwrap_or(observed_at);
+        let check_started_at_key = check_started_at.to_rfc3339();
+        let pr_number = completion.pr_number as i64;
+        let head_sha = completion.head_sha.clone();
+
+        let existing = self
+            .round_store
+            .get_by_key(repo_id, pr_number, &head_sha, &check_started_at_key)
+            .context("Check existing CodeRabbit round")?;
+
+        let mut round = if let Some(round) = existing {
+            round
+        } else {
+            let round = CodeRabbitRound::new(
+                repo_id,
+                Some(workspace_id),
+                pr_number,
+                head_sha.clone(),
+                completion.check_state.as_str().to_string(),
+                check_started_at,
+                observed_at,
+            );
+            self.round_store
+                .create(&round)
+                .context("Create CodeRabbit round")?;
+            round
+        };
+
+        if round.status == CodeRabbitRoundStatus::Complete {
+            return Ok(());
+        }
+
+        round.check_state = completion.check_state.as_str().to_string();
+        round.workspace_id = round.workspace_id.or(Some(workspace_id));
+        round.next_fetch_at = Some(observed_at);
+        round.updated_at = observed_at;
+        self.round_store
+            .update(&round)
+            .context("Update CodeRabbit round scheduling")?;
+
+        let working_dir = self.resolve_working_dir(&round)?;
+        self.fetch_and_update_round(round, &settings, &working_dir)
+    }
+
+    pub fn process_due_rounds(&self) -> Result<()> {
+        let now = Utc::now();
+        let due_rounds = self
+            .round_store
+            .list_pending_due(now)
+            .context("Load pending CodeRabbit rounds")?;
+        for round in due_rounds {
+            let settings = self
+                .settings_store
+                .get_or_default(round.repository_id)
+                .context("Load repository settings for CodeRabbit retry")?;
+            if settings.coderabbit_mode == CodeRabbitMode::Disabled {
+                continue;
+            }
+            let working_dir = match self.resolve_working_dir(&round) {
+                Ok(path) => path,
+                Err(error) => {
+                    tracing::warn!(
+                        round_id = %round.id,
+                        error = %error,
+                        "Skipping CodeRabbit round due to missing working dir"
+                    );
+                    continue;
+                }
+            };
+            if let Err(error) = self.fetch_and_update_round(round, &settings, &working_dir) {
+                tracing::warn!(
+                    error = %error,
+                    "CodeRabbit round processing failed"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    pub fn cleanup_rounds_if_needed(&self, repository_id: Uuid, pr_number: i64) -> Result<()> {
+        let settings = self
+            .settings_store
+            .get_or_default(repository_id)
+            .context("Load repository settings for CodeRabbit cleanup")?;
+        if settings.coderabbit_retention == crate::data::CodeRabbitRetention::DeleteOnClose {
+            self.round_store
+                .delete_by_pr(repository_id, pr_number)
+                .context("Delete CodeRabbit rounds for closed PR")?;
+        }
+        Ok(())
+    }
+
+    fn resolve_working_dir(&self, round: &CodeRabbitRound) -> Result<PathBuf> {
+        if let Some(workspace_id) = round.workspace_id {
+            if let Some(workspace) = self
+                .workspace_store
+                .get_by_id(workspace_id)
+                .context("Load workspace for CodeRabbit fetch")?
+            {
+                return Ok(workspace.path);
+            }
+        }
+        let repo = self
+            .repo_store
+            .get_by_id(round.repository_id)
+            .context("Load repository for CodeRabbit fetch")?
+            .ok_or_else(|| anyhow!("Repository not found for CodeRabbit fetch"))?;
+        repo.base_path
+            .clone()
+            .ok_or_else(|| anyhow!("Repository base path missing for CodeRabbit fetch"))
+    }
+
+    fn fetch_and_update_round(
+        &self,
+        mut round: CodeRabbitRound,
+        settings: &RepositorySettings,
+        working_dir: &Path,
+    ) -> Result<()> {
+        let observed_at = Utc::now();
+        let fetcher = CodeRabbitFetcher::new(working_dir.to_path_buf());
+        let items = match fetcher.fetch_actionable_items(
+            round.pr_number as u32,
+            &round.head_sha,
+            round.check_started_at,
+            observed_at,
+        ) {
+            Ok(items) => items,
+            Err(error) => {
+                tracing::warn!(
+                    round_id = %round.id,
+                    error = %error,
+                    "CodeRabbit fetch failed"
+                );
+                Vec::new()
+            }
+        };
+
+        let mut to_insert = Vec::new();
+        for item in items {
+            to_insert.push(CodeRabbitItem {
+                id: Uuid::new_v4(),
+                round_id: round.id,
+                comment_id: item.comment_id,
+                source: item.source,
+                category: item.category,
+                severity: item.severity,
+                file_path: item.file_path,
+                line: item.line,
+                original_line: item.original_line,
+                diff_hunk: item.diff_hunk,
+                html_url: item.html_url,
+                body: item.body,
+                agent_prompt: item.agent_prompt,
+                created_at: item.created_at,
+                updated_at: item.updated_at,
+            });
+        }
+
+        if !to_insert.is_empty() {
+            self.item_store
+                .insert_items(&to_insert)
+                .context("Insert CodeRabbit items")?;
+        }
+
+        let total_actionable = self
+            .item_store
+            .count_for_round(round.id)
+            .context("Count CodeRabbit items for round")?;
+
+        round.attempt_count += 1;
+        round.actionable_count = total_actionable;
+        round.updated_at = observed_at;
+
+        if total_actionable > 0 {
+            round.status = CodeRabbitRoundStatus::Complete;
+            round.completed_at = Some(observed_at);
+            round.next_fetch_at = None;
+            self.round_store
+                .update(&round)
+                .context("Finalize CodeRabbit round")?;
+            return Ok(());
+        }
+
+        let backoff = &settings.coderabbit_backoff_seconds;
+        if (round.attempt_count as usize) >= backoff.len() {
+            round.status = CodeRabbitRoundStatus::Complete;
+            round.completed_at = Some(observed_at);
+            round.next_fetch_at = None;
+        } else {
+            let delay = backoff[round.attempt_count as usize - 1];
+            round.next_fetch_at = Some(observed_at + Duration::seconds(delay));
+        }
+
+        self.round_store
+            .update(&round)
+            .context("Update CodeRabbit round after fetch")?;
+        Ok(())
+    }
+}
+
+struct CodeRabbitFetcher {
+    working_dir: PathBuf,
+}
+
+impl CodeRabbitFetcher {
+    fn new(working_dir: PathBuf) -> Self {
+        Self { working_dir }
+    }
+
+    fn fetch_actionable_items(
+        &self,
+        pr_number: u32,
+        head_sha: &str,
+        check_started_at: DateTime<Utc>,
+        observed_at: DateTime<Utc>,
+    ) -> Result<Vec<CodeRabbitItemDraft>> {
+        let window_start = Some(check_started_at);
+        let window_end = observed_at + Duration::minutes(CODERABBIT_WINDOW_SLACK_MINUTES);
+
+        let review_comments: Vec<GitHubReviewComment> = gh_api_paginated(
+            &self.working_dir,
+            &format!(
+                "repos/{{owner}}/{{repo}}/pulls/{}/comments?per_page=100",
+                pr_number
+            ),
+        )
+        .context("Fetch CodeRabbit review comments")?;
+
+        let issue_comments: Vec<GitHubIssueComment> = gh_api_paginated(
+            &self.working_dir,
+            &format!(
+                "repos/{{owner}}/{{repo}}/issues/{}/comments?per_page=100",
+                pr_number
+            ),
+        )
+        .context("Fetch CodeRabbit issue comments")?;
+
+        let reviews: Vec<GitHubReview> = gh_api_paginated(
+            &self.working_dir,
+            &format!(
+                "repos/{{owner}}/{{repo}}/pulls/{}/reviews?per_page=100",
+                pr_number
+            ),
+        )
+        .context("Fetch CodeRabbit reviews")?;
+
+        let mut drafts = Vec::new();
+
+        for comment in review_comments {
+            if !is_coderabbit_login(&comment.user.login) {
+                continue;
+            }
+            if !matches_commit_or_window(
+                comment.commit_id.as_deref(),
+                head_sha,
+                parse_timestamp(Some(&comment.created_at)),
+                window_start,
+                window_end,
+            ) {
+                continue;
+            }
+            if let Some((category, severity)) = parse_actionable(&comment.body) {
+                let created_at = parse_timestamp(Some(&comment.created_at)).unwrap_or(observed_at);
+                let updated_at = parse_timestamp(Some(&comment.updated_at)).unwrap_or(created_at);
+                drafts.push(CodeRabbitItemDraft {
+                    comment_id: comment.id,
+                    source: CodeRabbitItemSource::ReviewComment,
+                    category,
+                    severity,
+                    file_path: comment.path,
+                    line: comment.line,
+                    original_line: comment.original_line,
+                    diff_hunk: comment.diff_hunk,
+                    html_url: comment.html_url,
+                    body: comment.body.clone(),
+                    agent_prompt: extract_prompt_for_ai_agents(&comment.body),
+                    created_at,
+                    updated_at,
+                });
+            }
+        }
+
+        for comment in issue_comments {
+            if !is_coderabbit_login(&comment.user.login) {
+                continue;
+            }
+            if !matches_commit_or_window(
+                None,
+                head_sha,
+                parse_timestamp(Some(&comment.created_at)),
+                window_start,
+                window_end,
+            ) {
+                continue;
+            }
+            if let Some((category, severity)) = parse_actionable(&comment.body) {
+                let created_at = parse_timestamp(Some(&comment.created_at)).unwrap_or(observed_at);
+                let updated_at = parse_timestamp(Some(&comment.updated_at)).unwrap_or(created_at);
+                drafts.push(CodeRabbitItemDraft {
+                    comment_id: comment.id,
+                    source: CodeRabbitItemSource::IssueComment,
+                    category,
+                    severity,
+                    file_path: None,
+                    line: None,
+                    original_line: None,
+                    diff_hunk: None,
+                    html_url: comment.html_url,
+                    body: comment.body.clone(),
+                    agent_prompt: extract_prompt_for_ai_agents(&comment.body),
+                    created_at,
+                    updated_at,
+                });
+            }
+        }
+
+        for review in reviews {
+            if !is_coderabbit_login(&review.user.login) {
+                continue;
+            }
+            let body = review.body.unwrap_or_default();
+            if body.is_empty() {
+                continue;
+            }
+            if !matches_commit_or_window(
+                review.commit_id.as_deref(),
+                head_sha,
+                parse_timestamp(review.submitted_at.as_deref()),
+                window_start,
+                window_end,
+            ) {
+                continue;
+            }
+            if let Some((category, severity)) = parse_actionable(&body) {
+                let created_at =
+                    parse_timestamp(review.submitted_at.as_deref()).unwrap_or(observed_at);
+                drafts.push(CodeRabbitItemDraft {
+                    comment_id: review.id,
+                    source: CodeRabbitItemSource::Review,
+                    category,
+                    severity,
+                    file_path: None,
+                    line: None,
+                    original_line: None,
+                    diff_hunk: None,
+                    html_url: review.html_url,
+                    body: body.clone(),
+                    agent_prompt: extract_prompt_for_ai_agents(&body),
+                    created_at,
+                    updated_at: created_at,
+                });
+            }
+        }
+
+        Ok(drafts)
+    }
+}
+
+fn gh_api_paginated<T: DeserializeOwned>(working_dir: &Path, endpoint: &str) -> Result<Vec<T>> {
+    let output = Command::new("gh")
+        .args(["api", "--paginate", "--slurp", endpoint])
+        .current_dir(working_dir)
+        .output()
+        .context("Run gh api for CodeRabbit")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(anyhow!("gh api failed: {}", stderr.trim()));
+    }
+
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).context("Parse gh api output as JSON")?;
+    parse_paginated(value)
+}
+
+fn parse_paginated<T: DeserializeOwned>(value: serde_json::Value) -> Result<Vec<T>> {
+    match value {
+        serde_json::Value::Array(pages) => {
+            if pages
+                .iter()
+                .all(|page| matches!(page, serde_json::Value::Array(_)))
+            {
+                let mut items = Vec::new();
+                for page in pages {
+                    if let serde_json::Value::Array(entries) = page {
+                        for entry in entries {
+                            let parsed =
+                                serde_json::from_value(entry).context("Parse gh api item")?;
+                            items.push(parsed);
+                        }
+                    }
+                }
+                Ok(items)
+            } else {
+                let mut items = Vec::new();
+                for entry in pages {
+                    let parsed = serde_json::from_value(entry).context("Parse gh api item")?;
+                    items.push(parsed);
+                }
+                Ok(items)
+            }
+        }
+        other => {
+            let parsed = serde_json::from_value(other).context("Parse gh api payload")?;
+            Ok(vec![parsed])
+        }
+    }
+}
+
+fn is_coderabbit_login(login: &str) -> bool {
+    CODERABBIT_LOGINS
+        .iter()
+        .any(|candidate| candidate.eq_ignore_ascii_case(login))
+}
+
+fn matches_commit_or_window(
+    commit_id: Option<&str>,
+    head_sha: &str,
+    created_at: Option<DateTime<Utc>>,
+    window_start: Option<DateTime<Utc>>,
+    window_end: DateTime<Utc>,
+) -> bool {
+    if let Some(commit_id) = commit_id {
+        return commit_id.eq_ignore_ascii_case(head_sha);
+    }
+    if let Some(created_at) = created_at {
+        return within_window(created_at, window_start, window_end);
+    }
+    false
+}
+
+fn within_window(
+    created_at: DateTime<Utc>,
+    window_start: Option<DateTime<Utc>>,
+    window_end: DateTime<Utc>,
+) -> bool {
+    if created_at > window_end {
+        return false;
+    }
+    if let Some(start) = window_start {
+        return created_at >= start;
+    }
+    true
+}
+
+fn parse_actionable(body: &str) -> Option<(CodeRabbitCategory, Option<CodeRabbitSeverity>)> {
+    let lower = body.to_ascii_lowercase();
+    let category = if lower.contains("potential issue") {
+        CodeRabbitCategory::PotentialIssue
+    } else if lower.contains("refactor suggestion") {
+        CodeRabbitCategory::RefactorSuggestion
+    } else {
+        return None;
+    };
+
+    let severity = if lower.contains("critical") {
+        Some(CodeRabbitSeverity::Critical)
+    } else if lower.contains("major") {
+        Some(CodeRabbitSeverity::Major)
+    } else if lower.contains("minor") {
+        Some(CodeRabbitSeverity::Minor)
+    } else if lower.contains("trivial") {
+        Some(CodeRabbitSeverity::Trivial)
+    } else if lower.contains("info") {
+        Some(CodeRabbitSeverity::Info)
+    } else {
+        None
+    };
+
+    Some((category, severity))
+}
+
+fn extract_prompt_for_ai_agents(body: &str) -> Option<String> {
+    let marker = "Prompt for AI Agents";
+    let start = body.find(marker)?;
+    let rest = &body[start..];
+    let fence_start = rest.find("```")?;
+    let rest = &rest[fence_start + 3..];
+    let fence_end = rest.find("```")?;
+    let prompt = rest[..fence_end].trim();
+    if prompt.is_empty() {
+        None
+    } else {
+        Some(prompt.to_string())
+    }
+}
+
+fn parse_timestamp(value: Option<&str>) -> Option<DateTime<Utc>> {
+    value
+        .and_then(|raw| DateTime::parse_from_rfc3339(raw).ok())
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubUser {
+    login: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubReviewComment {
+    id: i64,
+    user: GitHubUser,
+    body: String,
+    html_url: String,
+    path: Option<String>,
+    line: Option<i64>,
+    original_line: Option<i64>,
+    diff_hunk: Option<String>,
+    commit_id: Option<String>,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubIssueComment {
+    id: i64,
+    user: GitHubUser,
+    body: String,
+    html_url: String,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubReview {
+    id: i64,
+    user: GitHubUser,
+    body: Option<String>,
+    html_url: String,
+    commit_id: Option<String>,
+    #[serde(rename = "submitted_at")]
+    submitted_at: Option<String>,
+}

--- a/src/config/default_keys.rs
+++ b/src/config/default_keys.rs
@@ -709,6 +709,42 @@ pub fn default_keybindings() -> KeybindingConfig {
         Action::Cancel,
     );
 
+    // ========== CodeRabbit Feedback ==========
+    let coderabbit = config
+        .context
+        .entry(KeyContext::CodeRabbitFeedback)
+        .or_default();
+
+    coderabbit.insert(
+        KeyCombo::new(KeyCode::Up, KeyModifiers::NONE),
+        Action::SelectPrev,
+    );
+    coderabbit.insert(
+        KeyCombo::new(KeyCode::Down, KeyModifiers::NONE),
+        Action::SelectNext,
+    );
+    bind(coderabbit, "k", Action::SelectPrev);
+    bind(coderabbit, "j", Action::SelectNext);
+    bind(coderabbit, "C-k", Action::SelectPrev);
+    bind(coderabbit, "C-j", Action::SelectNext);
+    bind(coderabbit, "C-f", Action::SelectPageDown);
+    bind(coderabbit, "C-b", Action::SelectPageUp);
+    coderabbit.insert(
+        KeyCombo::new(KeyCode::Char(' '), KeyModifiers::NONE),
+        Action::CodeRabbitToggleSelection,
+    );
+    bind(coderabbit, "a", Action::CodeRabbitSelectAll);
+    bind(coderabbit, "n", Action::CodeRabbitSelectNone);
+    bind(coderabbit, "f", Action::CodeRabbitCycleFilter);
+    coderabbit.insert(
+        KeyCombo::new(KeyCode::Enter, KeyModifiers::NONE),
+        Action::Confirm,
+    );
+    coderabbit.insert(
+        KeyCombo::new(KeyCode::Esc, KeyModifiers::NONE),
+        Action::Cancel,
+    );
+
     config
 }
 

--- a/src/config/keys.rs
+++ b/src/config/keys.rs
@@ -124,6 +124,8 @@ pub enum KeyContext {
     ThemePicker,
     /// Queue editor (inline)
     QueueEditing,
+    /// CodeRabbit feedback picker
+    CodeRabbitFeedback,
 }
 
 impl KeyContext {
@@ -145,6 +147,7 @@ impl KeyContext {
             KeyContext::CommandPalette,
             KeyContext::ThemePicker,
             KeyContext::QueueEditing,
+            KeyContext::CodeRabbitFeedback,
         ]
     }
 
@@ -174,6 +177,7 @@ impl KeyContext {
             InputMode::MissingTool => return KeyContext::Dialog,
             InputMode::SelectingTheme => return KeyContext::ThemePicker,
             InputMode::QueueEditing => return KeyContext::QueueEditing,
+            InputMode::CodeRabbitFeedback => return KeyContext::CodeRabbitFeedback,
             // Non-modal modes - continue to check view mode
             InputMode::Normal | InputMode::Scrolling | InputMode::SidebarNavigation => {}
         }

--- a/src/data/coderabbit.rs
+++ b/src/data/coderabbit.rs
@@ -123,8 +123,8 @@ impl RepositorySettingsStore {
 
         Ok(RepositorySettings {
             repository_id: Uuid::parse_str(&repo_id).unwrap_or_else(|_| Uuid::new_v4()),
-            coderabbit_mode: CodeRabbitMode::from_str(&mode),
-            coderabbit_retention: CodeRabbitRetention::from_str(&retention),
+            coderabbit_mode: CodeRabbitMode::parse(&mode),
+            coderabbit_retention: CodeRabbitRetention::parse(&retention),
             coderabbit_backoff_seconds: parse_backoff_seconds(&backoff_raw),
             updated_at: DateTime::parse_from_rfc3339(&updated_at_str)
                 .map(|dt| dt.with_timezone(&Utc))
@@ -279,7 +279,7 @@ impl CodeRabbitRoundStore {
             observed_at: DateTime::parse_from_rfc3339(&observed_at_str)
                 .map(|dt| dt.with_timezone(&Utc))
                 .unwrap_or_else(|_| Utc::now()),
-            status: CodeRabbitRoundStatus::from_str(&status_str),
+            status: CodeRabbitRoundStatus::parse(&status_str),
             attempt_count: row.get(9)?,
             next_fetch_at: next_fetch_at_str
                 .and_then(|value| DateTime::parse_from_rfc3339(&value).ok())

--- a/src/data/coderabbit.rs
+++ b/src/data/coderabbit.rs
@@ -1,0 +1,362 @@
+//! CodeRabbit persistence helpers.
+
+use chrono::{DateTime, Utc};
+use rusqlite::{params, Connection, Result as SqliteResult};
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
+
+use super::models::{
+    CodeRabbitCategory, CodeRabbitItem, CodeRabbitItemSource, CodeRabbitMode, CodeRabbitRetention,
+    CodeRabbitRound, CodeRabbitRoundStatus, CodeRabbitSeverity, RepositorySettings,
+};
+
+const DEFAULT_BACKOFF_SECONDS: &[i64] = &[30, 120, 300];
+
+fn parse_backoff_seconds(raw: &str) -> Vec<i64> {
+    let mut values = Vec::new();
+    for part in raw.split(',') {
+        let trimmed = part.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Ok(value) = trimmed.parse::<i64>() {
+            if value > 0 {
+                values.push(value);
+            }
+        }
+    }
+    if values.is_empty() {
+        DEFAULT_BACKOFF_SECONDS.to_vec()
+    } else {
+        values
+    }
+}
+
+fn backoff_to_string(values: &[i64]) -> String {
+    if values.is_empty() {
+        return DEFAULT_BACKOFF_SECONDS
+            .iter()
+            .map(|v| v.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+    }
+    values
+        .iter()
+        .map(|v| v.to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+#[derive(Clone)]
+pub struct RepositorySettingsStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl RepositorySettingsStore {
+    pub fn new(conn: Arc<Mutex<Connection>>) -> Self {
+        Self { conn }
+    }
+
+    pub fn get_by_repository(
+        &self,
+        repository_id: Uuid,
+    ) -> SqliteResult<Option<RepositorySettings>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT repository_id, coderabbit_mode, coderabbit_retention, coderabbit_backoff_seconds, updated_at
+             FROM repository_settings WHERE repository_id = ?1",
+        )?;
+        let mut rows = stmt.query(params![repository_id.to_string()])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(Self::row_to_settings(row)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn get_or_default(&self, repository_id: Uuid) -> SqliteResult<RepositorySettings> {
+        if let Some(settings) = self.get_by_repository(repository_id)? {
+            Ok(settings)
+        } else {
+            Ok(Self::default_settings(repository_id))
+        }
+    }
+
+    pub fn upsert(&self, settings: &RepositorySettings) -> SqliteResult<()> {
+        let conn = self.conn.lock().unwrap();
+        let updated_at = Utc::now().to_rfc3339();
+        conn.execute(
+            "INSERT INTO repository_settings (repository_id, coderabbit_mode, coderabbit_retention, coderabbit_backoff_seconds, updated_at)
+             VALUES (?1, ?2, ?3, ?4, ?5)
+             ON CONFLICT(repository_id) DO UPDATE SET
+                 coderabbit_mode = excluded.coderabbit_mode,
+                 coderabbit_retention = excluded.coderabbit_retention,
+                 coderabbit_backoff_seconds = excluded.coderabbit_backoff_seconds,
+                 updated_at = excluded.updated_at",
+            params![
+                settings.repository_id.to_string(),
+                settings.coderabbit_mode.as_str(),
+                settings.coderabbit_retention.as_str(),
+                backoff_to_string(&settings.coderabbit_backoff_seconds),
+                updated_at,
+            ],
+        )?;
+        Ok(())
+    }
+
+    fn default_settings(repository_id: Uuid) -> RepositorySettings {
+        RepositorySettings {
+            repository_id,
+            coderabbit_mode: CodeRabbitMode::Auto,
+            coderabbit_retention: CodeRabbitRetention::Keep,
+            coderabbit_backoff_seconds: DEFAULT_BACKOFF_SECONDS.to_vec(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    fn row_to_settings(row: &rusqlite::Row) -> SqliteResult<RepositorySettings> {
+        let repo_id: String = row.get(0)?;
+        let mode: String = row.get(1)?;
+        let retention: String = row.get(2)?;
+        let backoff_raw: String = row.get(3)?;
+        let updated_at_str: String = row.get(4)?;
+
+        Ok(RepositorySettings {
+            repository_id: Uuid::parse_str(&repo_id).unwrap_or_else(|_| Uuid::new_v4()),
+            coderabbit_mode: CodeRabbitMode::from_str(&mode),
+            coderabbit_retention: CodeRabbitRetention::from_str(&retention),
+            coderabbit_backoff_seconds: parse_backoff_seconds(&backoff_raw),
+            updated_at: DateTime::parse_from_rfc3339(&updated_at_str)
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(|_| Utc::now()),
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct CodeRabbitRoundStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl CodeRabbitRoundStore {
+    pub fn new(conn: Arc<Mutex<Connection>>) -> Self {
+        Self { conn }
+    }
+
+    pub fn create(&self, round: &CodeRabbitRound) -> SqliteResult<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "INSERT INTO coderabbit_rounds (
+                id, repository_id, workspace_id, pr_number, head_sha, check_state, check_started_at,
+                observed_at, status, attempt_count, next_fetch_at, actionable_count, completed_at,
+                created_at, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+            params![
+                round.id.to_string(),
+                round.repository_id.to_string(),
+                round.workspace_id.map(|id| id.to_string()),
+                round.pr_number,
+                round.head_sha,
+                round.check_state,
+                round.check_started_at.to_rfc3339(),
+                round.observed_at.to_rfc3339(),
+                round.status.as_str(),
+                round.attempt_count,
+                round.next_fetch_at.map(|dt| dt.to_rfc3339()),
+                round.actionable_count,
+                round.completed_at.map(|dt| dt.to_rfc3339()),
+                round.created_at.to_rfc3339(),
+                round.updated_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn get_by_key(
+        &self,
+        repository_id: Uuid,
+        pr_number: i64,
+        head_sha: &str,
+        check_started_at: &str,
+    ) -> SqliteResult<Option<CodeRabbitRound>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, repository_id, workspace_id, pr_number, head_sha, check_state, check_started_at,
+                    observed_at, status, attempt_count, next_fetch_at, actionable_count, completed_at,
+                    created_at, updated_at
+             FROM coderabbit_rounds
+             WHERE repository_id = ?1 AND pr_number = ?2 AND head_sha = ?3 AND check_started_at = ?4",
+        )?;
+        let mut rows = stmt.query(params![
+            repository_id.to_string(),
+            pr_number,
+            head_sha,
+            check_started_at
+        ])?;
+        if let Some(row) = rows.next()? {
+            Ok(Some(Self::row_to_round(row)?))
+        } else {
+            Ok(None)
+        }
+    }
+
+    pub fn list_pending_due(&self, now: DateTime<Utc>) -> SqliteResult<Vec<CodeRabbitRound>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn.prepare(
+            "SELECT id, repository_id, workspace_id, pr_number, head_sha, check_state, check_started_at,
+                    observed_at, status, attempt_count, next_fetch_at, actionable_count, completed_at,
+                    created_at, updated_at
+             FROM coderabbit_rounds
+             WHERE status = 'pending'
+               AND next_fetch_at IS NOT NULL
+               AND next_fetch_at <= ?1
+             ORDER BY next_fetch_at ASC",
+        )?;
+        let rounds = stmt
+            .query_map(params![now.to_rfc3339()], Self::row_to_round)?
+            .filter_map(|row| row.ok())
+            .collect();
+        Ok(rounds)
+    }
+
+    pub fn update(&self, round: &CodeRabbitRound) -> SqliteResult<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE coderabbit_rounds SET
+                workspace_id = ?2,
+                status = ?3,
+                attempt_count = ?4,
+                next_fetch_at = ?5,
+                actionable_count = ?6,
+                completed_at = ?7,
+                updated_at = ?8
+             WHERE id = ?1",
+            params![
+                round.id.to_string(),
+                round.workspace_id.map(|id| id.to_string()),
+                round.status.as_str(),
+                round.attempt_count,
+                round.next_fetch_at.map(|dt| dt.to_rfc3339()),
+                round.actionable_count,
+                round.completed_at.map(|dt| dt.to_rfc3339()),
+                round.updated_at.to_rfc3339(),
+            ],
+        )?;
+        Ok(())
+    }
+
+    pub fn delete_by_pr(&self, repository_id: Uuid, pr_number: i64) -> SqliteResult<()> {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "DELETE FROM coderabbit_rounds WHERE repository_id = ?1 AND pr_number = ?2",
+            params![repository_id.to_string(), pr_number],
+        )?;
+        Ok(())
+    }
+
+    fn row_to_round(row: &rusqlite::Row) -> SqliteResult<CodeRabbitRound> {
+        let id_str: String = row.get(0)?;
+        let repo_id_str: String = row.get(1)?;
+        let workspace_id_str: Option<String> = row.get(2)?;
+        let check_started_at_str: String = row.get(6)?;
+        let observed_at_str: String = row.get(7)?;
+        let status_str: String = row.get(8)?;
+        let next_fetch_at_str: Option<String> = row.get(10)?;
+        let completed_at_str: Option<String> = row.get(12)?;
+        let created_at_str: String = row.get(13)?;
+        let updated_at_str: String = row.get(14)?;
+
+        Ok(CodeRabbitRound {
+            id: Uuid::parse_str(&id_str).unwrap_or_else(|_| Uuid::new_v4()),
+            repository_id: Uuid::parse_str(&repo_id_str).unwrap_or_else(|_| Uuid::new_v4()),
+            workspace_id: workspace_id_str.and_then(|value| Uuid::parse_str(&value).ok()),
+            pr_number: row.get(3)?,
+            head_sha: row.get(4)?,
+            check_state: row.get(5)?,
+            check_started_at: DateTime::parse_from_rfc3339(&check_started_at_str)
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(|_| Utc::now()),
+            observed_at: DateTime::parse_from_rfc3339(&observed_at_str)
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(|_| Utc::now()),
+            status: CodeRabbitRoundStatus::from_str(&status_str),
+            attempt_count: row.get(9)?,
+            next_fetch_at: next_fetch_at_str
+                .and_then(|value| DateTime::parse_from_rfc3339(&value).ok())
+                .map(|dt| dt.with_timezone(&Utc)),
+            actionable_count: row.get(11)?,
+            completed_at: completed_at_str
+                .and_then(|value| DateTime::parse_from_rfc3339(&value).ok())
+                .map(|dt| dt.with_timezone(&Utc)),
+            created_at: DateTime::parse_from_rfc3339(&created_at_str)
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(|_| Utc::now()),
+            updated_at: DateTime::parse_from_rfc3339(&updated_at_str)
+                .map(|dt| dt.with_timezone(&Utc))
+                .unwrap_or_else(|_| Utc::now()),
+        })
+    }
+}
+
+#[derive(Clone)]
+pub struct CodeRabbitItemStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl CodeRabbitItemStore {
+    pub fn new(conn: Arc<Mutex<Connection>>) -> Self {
+        Self { conn }
+    }
+
+    pub fn insert_items(&self, items: &[CodeRabbitItem]) -> SqliteResult<usize> {
+        let conn = self.conn.lock().unwrap();
+        let mut inserted = 0usize;
+        for item in items {
+            let rows = conn.execute(
+                "INSERT OR IGNORE INTO coderabbit_items (
+                    id, round_id, comment_id, source, category, severity, file_path, line,
+                    original_line, diff_hunk, html_url, body, agent_prompt, created_at, updated_at
+                 ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)",
+                params![
+                    item.id.to_string(),
+                    item.round_id.to_string(),
+                    item.comment_id,
+                    item.source.as_str(),
+                    item.category.as_str(),
+                    item.severity.map(|severity| severity.as_str()),
+                    item.file_path,
+                    item.line,
+                    item.original_line,
+                    item.diff_hunk,
+                    item.html_url,
+                    item.body,
+                    item.agent_prompt,
+                    item.created_at.to_rfc3339(),
+                    item.updated_at.to_rfc3339(),
+                ],
+            )?;
+            if rows > 0 {
+                inserted += 1;
+            }
+        }
+        Ok(inserted)
+    }
+
+    pub fn count_for_round(&self, round_id: Uuid) -> SqliteResult<i64> {
+        let conn = self.conn.lock().unwrap();
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM coderabbit_items WHERE round_id = ?1",
+            params![round_id.to_string()],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+}
+
+#[allow(dead_code)]
+fn _assert_enum_strs() {
+    let _ = CodeRabbitCategory::PotentialIssue.as_str();
+    let _ = CodeRabbitItemSource::ReviewComment.as_str();
+    let _ = CodeRabbitRoundStatus::Pending.as_str();
+    let _ = CodeRabbitSeverity::Critical.as_str();
+}

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -3,6 +3,7 @@
 //! This module provides SQLite-based storage for repositories and workspaces.
 
 mod app_state;
+mod coderabbit;
 mod database;
 mod fork_seed;
 mod models;
@@ -11,11 +12,13 @@ mod session_tab;
 mod workspace;
 
 pub use app_state::AppStateStore;
+pub use coderabbit::{CodeRabbitItemStore, CodeRabbitRoundStore, RepositorySettingsStore};
 pub use database::Database;
 pub use fork_seed::ForkSeedStore;
 pub use models::{
-    ForkSeed, QueuedImageAttachment, QueuedMessage, QueuedMessageMode, Repository, SessionTab,
-    Workspace,
+    CodeRabbitCategory, CodeRabbitItem, CodeRabbitItemSource, CodeRabbitMode, CodeRabbitRetention,
+    CodeRabbitRound, CodeRabbitRoundStatus, CodeRabbitSeverity, ForkSeed, QueuedImageAttachment,
+    QueuedMessage, QueuedMessageMode, Repository, RepositorySettings, SessionTab, Workspace,
 };
 pub use repository::RepositoryStore;
 pub use session_tab::SessionTabStore;

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -12,13 +12,16 @@ mod session_tab;
 mod workspace;
 
 pub use app_state::AppStateStore;
-pub use coderabbit::{CodeRabbitItemStore, CodeRabbitRoundStore, RepositorySettingsStore};
+pub use coderabbit::{
+    CodeRabbitCommentStore, CodeRabbitItemStore, CodeRabbitRoundStore, RepositorySettingsStore,
+};
 pub use database::Database;
 pub use fork_seed::ForkSeedStore;
 pub use models::{
-    CodeRabbitCategory, CodeRabbitItem, CodeRabbitItemSource, CodeRabbitMode, CodeRabbitRetention,
-    CodeRabbitRound, CodeRabbitRoundStatus, CodeRabbitSeverity, ForkSeed, QueuedImageAttachment,
-    QueuedMessage, QueuedMessageMode, Repository, RepositorySettings, SessionTab, Workspace,
+    CodeRabbitCategory, CodeRabbitComment, CodeRabbitFeedbackScope, CodeRabbitItem,
+    CodeRabbitItemKind, CodeRabbitItemSource, CodeRabbitMode, CodeRabbitRetention, CodeRabbitRound,
+    CodeRabbitRoundStatus, CodeRabbitSeverity, ForkSeed, QueuedImageAttachment, QueuedMessage,
+    QueuedMessageMode, Repository, RepositorySettings, SessionTab, Workspace,
 };
 pub use repository::RepositoryStore;
 pub use session_tab::SessionTabStore;

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -19,9 +19,10 @@ pub use database::Database;
 pub use fork_seed::ForkSeedStore;
 pub use models::{
     CodeRabbitCategory, CodeRabbitComment, CodeRabbitFeedbackScope, CodeRabbitItem,
-    CodeRabbitItemKind, CodeRabbitItemSource, CodeRabbitMode, CodeRabbitRetention, CodeRabbitRound,
-    CodeRabbitRoundStatus, CodeRabbitSeverity, ForkSeed, QueuedImageAttachment, QueuedMessage,
-    QueuedMessageMode, Repository, RepositorySettings, SessionTab, Workspace,
+    CodeRabbitItemKind, CodeRabbitItemSource, CodeRabbitMode, CodeRabbitRetention,
+    CodeRabbitReviewLoopDoneCondition, CodeRabbitRound, CodeRabbitRoundStatus, CodeRabbitSeverity,
+    ForkSeed, QueuedImageAttachment, QueuedMessage, QueuedMessageMode, Repository,
+    RepositorySettings, SessionTab, Workspace,
 };
 pub use repository::RepositoryStore;
 pub use session_tab::SessionTabStore;

--- a/src/data/models.rs
+++ b/src/data/models.rs
@@ -216,6 +216,239 @@ impl SessionTab {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CodeRabbitMode {
+    Auto,
+    Enabled,
+    Disabled,
+}
+
+impl CodeRabbitMode {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CodeRabbitMode::Auto => "auto",
+            CodeRabbitMode::Enabled => "enabled",
+            CodeRabbitMode::Disabled => "disabled",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Self {
+        match value.to_ascii_lowercase().as_str() {
+            "enabled" => CodeRabbitMode::Enabled,
+            "disabled" => CodeRabbitMode::Disabled,
+            _ => CodeRabbitMode::Auto,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CodeRabbitRetention {
+    Keep,
+    DeleteOnClose,
+}
+
+impl CodeRabbitRetention {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CodeRabbitRetention::Keep => "keep",
+            CodeRabbitRetention::DeleteOnClose => "delete-on-close",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Self {
+        match value.to_ascii_lowercase().as_str() {
+            "delete-on-close" => CodeRabbitRetention::DeleteOnClose,
+            _ => CodeRabbitRetention::Keep,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct RepositorySettings {
+    pub repository_id: Uuid,
+    pub coderabbit_mode: CodeRabbitMode,
+    pub coderabbit_retention: CodeRabbitRetention,
+    pub coderabbit_backoff_seconds: Vec<i64>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CodeRabbitRoundStatus {
+    Pending,
+    Complete,
+}
+
+impl CodeRabbitRoundStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CodeRabbitRoundStatus::Pending => "pending",
+            CodeRabbitRoundStatus::Complete => "complete",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Self {
+        match value.to_ascii_lowercase().as_str() {
+            "complete" => CodeRabbitRoundStatus::Complete,
+            _ => CodeRabbitRoundStatus::Pending,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CodeRabbitItemSource {
+    ReviewComment,
+    IssueComment,
+    Review,
+}
+
+impl CodeRabbitItemSource {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CodeRabbitItemSource::ReviewComment => "review-comment",
+            CodeRabbitItemSource::IssueComment => "issue-comment",
+            CodeRabbitItemSource::Review => "review",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Self {
+        match value.to_ascii_lowercase().as_str() {
+            "issue-comment" => CodeRabbitItemSource::IssueComment,
+            "review" => CodeRabbitItemSource::Review,
+            _ => CodeRabbitItemSource::ReviewComment,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CodeRabbitCategory {
+    PotentialIssue,
+    RefactorSuggestion,
+}
+
+impl CodeRabbitCategory {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CodeRabbitCategory::PotentialIssue => "potential-issue",
+            CodeRabbitCategory::RefactorSuggestion => "refactor-suggestion",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "potential-issue" => Some(CodeRabbitCategory::PotentialIssue),
+            "refactor-suggestion" => Some(CodeRabbitCategory::RefactorSuggestion),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum CodeRabbitSeverity {
+    Critical,
+    Major,
+    Minor,
+    Trivial,
+    Info,
+}
+
+impl CodeRabbitSeverity {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CodeRabbitSeverity::Critical => "critical",
+            CodeRabbitSeverity::Major => "major",
+            CodeRabbitSeverity::Minor => "minor",
+            CodeRabbitSeverity::Trivial => "trivial",
+            CodeRabbitSeverity::Info => "info",
+        }
+    }
+
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value.to_ascii_lowercase().as_str() {
+            "critical" => Some(CodeRabbitSeverity::Critical),
+            "major" => Some(CodeRabbitSeverity::Major),
+            "minor" => Some(CodeRabbitSeverity::Minor),
+            "trivial" => Some(CodeRabbitSeverity::Trivial),
+            "info" => Some(CodeRabbitSeverity::Info),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CodeRabbitRound {
+    pub id: Uuid,
+    pub repository_id: Uuid,
+    pub workspace_id: Option<Uuid>,
+    pub pr_number: i64,
+    pub head_sha: String,
+    pub check_state: String,
+    pub check_started_at: DateTime<Utc>,
+    pub observed_at: DateTime<Utc>,
+    pub status: CodeRabbitRoundStatus,
+    pub attempt_count: i64,
+    pub next_fetch_at: Option<DateTime<Utc>>,
+    pub actionable_count: i64,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl CodeRabbitRound {
+    pub fn new(
+        repository_id: Uuid,
+        workspace_id: Option<Uuid>,
+        pr_number: i64,
+        head_sha: String,
+        check_state: String,
+        check_started_at: DateTime<Utc>,
+        observed_at: DateTime<Utc>,
+    ) -> Self {
+        let now = Utc::now();
+        Self {
+            id: Uuid::new_v4(),
+            repository_id,
+            workspace_id,
+            pr_number,
+            head_sha,
+            check_state,
+            check_started_at,
+            observed_at,
+            status: CodeRabbitRoundStatus::Pending,
+            attempt_count: 0,
+            next_fetch_at: Some(observed_at),
+            actionable_count: 0,
+            completed_at: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct CodeRabbitItem {
+    pub id: Uuid,
+    pub round_id: Uuid,
+    pub comment_id: i64,
+    pub source: CodeRabbitItemSource,
+    pub category: CodeRabbitCategory,
+    pub severity: Option<CodeRabbitSeverity>,
+    pub file_path: Option<String>,
+    pub line: Option<i64>,
+    pub original_line: Option<i64>,
+    pub diff_hunk: Option<String>,
+    pub html_url: String,
+    pub body: String,
+    pub agent_prompt: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
 /// Metadata for a forked session seed prompt
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ForkSeed {

--- a/src/data/models.rs
+++ b/src/data/models.rs
@@ -233,7 +233,7 @@ impl CodeRabbitMode {
         }
     }
 
-    pub fn from_str(value: &str) -> Self {
+    pub fn parse(value: &str) -> Self {
         match value.to_ascii_lowercase().as_str() {
             "enabled" => CodeRabbitMode::Enabled,
             "disabled" => CodeRabbitMode::Disabled,
@@ -246,7 +246,7 @@ impl std::str::FromStr for CodeRabbitMode {
     type Err = std::convert::Infallible;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(CodeRabbitMode::from_str(value))
+        Ok(CodeRabbitMode::parse(value))
     }
 }
 
@@ -265,7 +265,7 @@ impl CodeRabbitRetention {
         }
     }
 
-    pub fn from_str(value: &str) -> Self {
+    pub fn parse(value: &str) -> Self {
         match value.to_ascii_lowercase().as_str() {
             "delete-on-close" => CodeRabbitRetention::DeleteOnClose,
             _ => CodeRabbitRetention::Keep,
@@ -277,7 +277,7 @@ impl std::str::FromStr for CodeRabbitRetention {
     type Err = std::convert::Infallible;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(CodeRabbitRetention::from_str(value))
+        Ok(CodeRabbitRetention::parse(value))
     }
 }
 
@@ -305,7 +305,7 @@ impl CodeRabbitRoundStatus {
         }
     }
 
-    pub fn from_str(value: &str) -> Self {
+    pub fn parse(value: &str) -> Self {
         match value.to_ascii_lowercase().as_str() {
             "complete" => CodeRabbitRoundStatus::Complete,
             _ => CodeRabbitRoundStatus::Pending,
@@ -317,7 +317,7 @@ impl std::str::FromStr for CodeRabbitRoundStatus {
     type Err = std::convert::Infallible;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(CodeRabbitRoundStatus::from_str(value))
+        Ok(CodeRabbitRoundStatus::parse(value))
     }
 }
 
@@ -338,7 +338,7 @@ impl CodeRabbitItemSource {
         }
     }
 
-    pub fn from_str(value: &str) -> Self {
+    pub fn parse(value: &str) -> Self {
         match value.to_ascii_lowercase().as_str() {
             "issue-comment" => CodeRabbitItemSource::IssueComment,
             "review" => CodeRabbitItemSource::Review,
@@ -351,7 +351,7 @@ impl std::str::FromStr for CodeRabbitItemSource {
     type Err = std::convert::Infallible;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        Ok(CodeRabbitItemSource::from_str(value))
+        Ok(CodeRabbitItemSource::parse(value))
     }
 }
 
@@ -370,7 +370,7 @@ impl CodeRabbitCategory {
         }
     }
 
-    pub fn from_str(value: &str) -> Option<Self> {
+    pub fn parse(value: &str) -> Option<Self> {
         value.parse().ok()
     }
 }
@@ -379,11 +379,7 @@ impl std::str::FromStr for CodeRabbitCategory {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.to_ascii_lowercase().as_str() {
-            "potential-issue" => Ok(CodeRabbitCategory::PotentialIssue),
-            "refactor-suggestion" => Ok(CodeRabbitCategory::RefactorSuggestion),
-            _ => Err(()),
-        }
+        CodeRabbitCategory::parse(value).ok_or(())
     }
 }
 
@@ -408,7 +404,7 @@ impl CodeRabbitSeverity {
         }
     }
 
-    pub fn from_str(value: &str) -> Option<Self> {
+    pub fn parse(value: &str) -> Option<Self> {
         value.parse().ok()
     }
 }
@@ -417,14 +413,7 @@ impl std::str::FromStr for CodeRabbitSeverity {
     type Err = ();
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value.to_ascii_lowercase().as_str() {
-            "critical" => Ok(CodeRabbitSeverity::Critical),
-            "major" => Ok(CodeRabbitSeverity::Major),
-            "minor" => Ok(CodeRabbitSeverity::Minor),
-            "trivial" => Ok(CodeRabbitSeverity::Trivial),
-            "info" => Ok(CodeRabbitSeverity::Info),
-            _ => Err(()),
-        }
+        CodeRabbitSeverity::parse(value).ok_or(())
     }
 }
 

--- a/src/data/models.rs
+++ b/src/data/models.rs
@@ -242,6 +242,14 @@ impl CodeRabbitMode {
     }
 }
 
+impl std::str::FromStr for CodeRabbitMode {
+    type Err = std::convert::Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(CodeRabbitMode::from_str(value))
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum CodeRabbitRetention {
@@ -262,6 +270,14 @@ impl CodeRabbitRetention {
             "delete-on-close" => CodeRabbitRetention::DeleteOnClose,
             _ => CodeRabbitRetention::Keep,
         }
+    }
+}
+
+impl std::str::FromStr for CodeRabbitRetention {
+    type Err = std::convert::Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(CodeRabbitRetention::from_str(value))
     }
 }
 
@@ -297,6 +313,14 @@ impl CodeRabbitRoundStatus {
     }
 }
 
+impl std::str::FromStr for CodeRabbitRoundStatus {
+    type Err = std::convert::Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(CodeRabbitRoundStatus::from_str(value))
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum CodeRabbitItemSource {
@@ -323,6 +347,14 @@ impl CodeRabbitItemSource {
     }
 }
 
+impl std::str::FromStr for CodeRabbitItemSource {
+    type Err = std::convert::Infallible;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(CodeRabbitItemSource::from_str(value))
+    }
+}
+
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
 pub enum CodeRabbitCategory {
@@ -339,10 +371,18 @@ impl CodeRabbitCategory {
     }
 
     pub fn from_str(value: &str) -> Option<Self> {
+        value.parse().ok()
+    }
+}
+
+impl std::str::FromStr for CodeRabbitCategory {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value.to_ascii_lowercase().as_str() {
-            "potential-issue" => Some(CodeRabbitCategory::PotentialIssue),
-            "refactor-suggestion" => Some(CodeRabbitCategory::RefactorSuggestion),
-            _ => None,
+            "potential-issue" => Ok(CodeRabbitCategory::PotentialIssue),
+            "refactor-suggestion" => Ok(CodeRabbitCategory::RefactorSuggestion),
+            _ => Err(()),
         }
     }
 }
@@ -369,13 +409,21 @@ impl CodeRabbitSeverity {
     }
 
     pub fn from_str(value: &str) -> Option<Self> {
+        value.parse().ok()
+    }
+}
+
+impl std::str::FromStr for CodeRabbitSeverity {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value.to_ascii_lowercase().as_str() {
-            "critical" => Some(CodeRabbitSeverity::Critical),
-            "major" => Some(CodeRabbitSeverity::Major),
-            "minor" => Some(CodeRabbitSeverity::Minor),
-            "trivial" => Some(CodeRabbitSeverity::Trivial),
-            "info" => Some(CodeRabbitSeverity::Info),
-            _ => None,
+            "critical" => Ok(CodeRabbitSeverity::Critical),
+            "major" => Ok(CodeRabbitSeverity::Major),
+            "minor" => Ok(CodeRabbitSeverity::Minor),
+            "trivial" => Ok(CodeRabbitSeverity::Trivial),
+            "info" => Ok(CodeRabbitSeverity::Info),
+            _ => Err(()),
         }
     }
 }

--- a/src/data/models.rs
+++ b/src/data/models.rs
@@ -371,7 +371,11 @@ impl CodeRabbitCategory {
     }
 
     pub fn parse(value: &str) -> Option<Self> {
-        value.parse().ok()
+        match value.to_ascii_lowercase().as_str() {
+            "potential-issue" => Some(CodeRabbitCategory::PotentialIssue),
+            "refactor-suggestion" => Some(CodeRabbitCategory::RefactorSuggestion),
+            _ => None,
+        }
     }
 }
 
@@ -405,7 +409,14 @@ impl CodeRabbitSeverity {
     }
 
     pub fn parse(value: &str) -> Option<Self> {
-        value.parse().ok()
+        match value.to_ascii_lowercase().as_str() {
+            "critical" => Some(CodeRabbitSeverity::Critical),
+            "major" => Some(CodeRabbitSeverity::Major),
+            "minor" => Some(CodeRabbitSeverity::Minor),
+            "trivial" => Some(CodeRabbitSeverity::Trivial),
+            "info" => Some(CodeRabbitSeverity::Info),
+            _ => None,
+        }
     }
 }
 

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -6,7 +6,7 @@ mod worktree;
 
 pub use pr::{
     CheckState, CheckStatus, MergeReadiness, MergeableStatus, PrManager, PrPreflightResult,
-    PrState, PrStatus, ReviewDecision,
+    PrState, PrStatus, PrStatusCheck, PrStatusCheckKind, ReviewDecision,
 };
 pub use status::GitDiffStats;
 pub use worktree::{WorktreeInfo, WorktreeManager};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,8 @@ pub use agent::{
 };
 pub use config::Config;
 pub use data::{
-    CodeRabbitCategory, CodeRabbitItem, CodeRabbitItemSource, CodeRabbitItemStore, CodeRabbitMode,
+    CodeRabbitCategory, CodeRabbitComment, CodeRabbitCommentStore, CodeRabbitFeedbackScope,
+    CodeRabbitItem, CodeRabbitItemKind, CodeRabbitItemSource, CodeRabbitItemStore, CodeRabbitMode,
     CodeRabbitRetention, CodeRabbitRound, CodeRabbitRoundStatus, CodeRabbitRoundStore,
     CodeRabbitSeverity, Database, Repository, RepositorySettings, RepositorySettingsStore,
     RepositoryStore, Workspace, WorkspaceStore,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod agent;
+pub mod coderabbit;
 pub mod config;
 pub mod data;
 pub mod git;
@@ -13,7 +14,12 @@ pub use agent::{
     SessionStatus,
 };
 pub use config::Config;
-pub use data::{Database, Repository, RepositoryStore, Workspace, WorkspaceStore};
+pub use data::{
+    CodeRabbitCategory, CodeRabbitItem, CodeRabbitItemSource, CodeRabbitItemStore, CodeRabbitMode,
+    CodeRabbitRetention, CodeRabbitRound, CodeRabbitRoundStatus, CodeRabbitRoundStore,
+    CodeRabbitSeverity, Database, Repository, RepositorySettings, RepositorySettingsStore,
+    RepositoryStore, Workspace, WorkspaceStore,
+};
 pub use git::{
     CheckState, CheckStatus, MergeReadiness, MergeableStatus, PrManager, PrPreflightResult,
     PrState, PrStatus, ReviewDecision, WorktreeInfo, WorktreeManager,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,9 +17,9 @@ pub use config::Config;
 pub use data::{
     CodeRabbitCategory, CodeRabbitComment, CodeRabbitCommentStore, CodeRabbitFeedbackScope,
     CodeRabbitItem, CodeRabbitItemKind, CodeRabbitItemSource, CodeRabbitItemStore, CodeRabbitMode,
-    CodeRabbitRetention, CodeRabbitRound, CodeRabbitRoundStatus, CodeRabbitRoundStore,
-    CodeRabbitSeverity, Database, Repository, RepositorySettings, RepositorySettingsStore,
-    RepositoryStore, Workspace, WorkspaceStore,
+    CodeRabbitRetention, CodeRabbitReviewLoopDoneCondition, CodeRabbitRound, CodeRabbitRoundStatus,
+    CodeRabbitRoundStore, CodeRabbitSeverity, Database, Repository, RepositorySettings,
+    RepositorySettingsStore, RepositoryStore, Workspace, WorkspaceStore,
 };
 pub use git::{
     CheckState, CheckStatus, MergeReadiness, MergeableStatus, PrManager, PrPreflightResult,

--- a/src/ui/action.rs
+++ b/src/ui/action.rs
@@ -40,6 +40,10 @@ pub enum Action {
     CopyWorkspacePath,
     /// Copy active selection to clipboard
     CopySelection,
+    /// Open CodeRabbit feedback picker
+    OpenCodeRabbitFeedback,
+    /// Toggle Review Loop for current repo
+    ToggleReviewLoop,
 
     // ========== Tab Management ==========
     /// Close current tab
@@ -218,6 +222,16 @@ pub enum Action {
     // ========== Command Palette ==========
     /// Open command palette
     OpenCommandPalette,
+
+    // ========== CodeRabbit Feedback ==========
+    /// Toggle selection in CodeRabbit feedback list
+    CodeRabbitToggleSelection,
+    /// Select all CodeRabbit feedback items
+    CodeRabbitSelectAll,
+    /// Clear CodeRabbit feedback selection
+    CodeRabbitSelectNone,
+    /// Cycle CodeRabbit feedback filter
+    CodeRabbitCycleFilter,
 }
 
 impl Action {
@@ -240,6 +254,8 @@ impl Action {
             Action::Suspend => "Suspend",
             Action::CopyWorkspacePath => "Copy workspace path",
             Action::CopySelection => "Copy selection",
+            Action::OpenCodeRabbitFeedback => "CodeRabbit feedback",
+            Action::ToggleReviewLoop => "Toggle Review Loop",
 
             // Tab management
             Action::CloseTab => "Close tab",
@@ -341,6 +357,10 @@ impl Action {
 
             // Command palette
             Action::OpenCommandPalette => "Command palette",
+            Action::CodeRabbitToggleSelection => "Toggle selection",
+            Action::CodeRabbitSelectAll => "Select all",
+            Action::CodeRabbitSelectNone => "Select none",
+            Action::CodeRabbitCycleFilter => "Cycle filter",
         }
     }
 
@@ -353,6 +373,7 @@ impl Action {
                 | Action::ShowThemePicker
                 | Action::OpenQueueEditor
                 | Action::OpenSessionImport
+                | Action::OpenCodeRabbitFeedback
                 | Action::ShowHelp
                 | Action::AddRepository
                 | Action::OpenSettings
@@ -380,6 +401,8 @@ impl Action {
                 | Action::DumpDebugState
                 | Action::CopyWorkspacePath
                 | Action::CopySelection
+                | Action::OpenCodeRabbitFeedback
+                | Action::ToggleReviewLoop
                 // Tab management
                 | Action::CloseTab
                 | Action::NextTab

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -35,9 +35,9 @@ use crate::agent::{
 use crate::coderabbit::{CodeRabbitCompletion, CodeRabbitProcessor};
 use crate::config::{parse_action, parse_key_notation, Config, KeyContext, COMMAND_NAMES};
 use crate::data::{
-    AppStateStore, CodeRabbitItemStore, CodeRabbitRoundStore, Database, ForkSeed, ForkSeedStore,
-    QueuedImageAttachment, QueuedMessage, QueuedMessageMode, Repository, RepositorySettingsStore,
-    RepositoryStore, SessionTab, SessionTabStore, WorkspaceStore,
+    AppStateStore, CodeRabbitCommentStore, CodeRabbitItemStore, CodeRabbitRoundStore, Database,
+    ForkSeed, ForkSeedStore, QueuedImageAttachment, QueuedMessage, QueuedMessageMode, Repository,
+    RepositorySettingsStore, RepositoryStore, SessionTab, SessionTabStore, WorkspaceStore,
 };
 use crate::git::{PrManager, PrStatus, WorktreeManager};
 use crate::ui::action::Action;
@@ -220,6 +220,7 @@ impl App {
             fork_seed_dao,
             repo_settings_dao,
             coderabbit_round_dao,
+            coderabbit_comment_dao,
             coderabbit_item_dao,
         ) = match Database::open_default() {
             Ok(db) => {
@@ -230,6 +231,7 @@ impl App {
                 let fork_seed_dao = ForkSeedStore::new(db.connection());
                 let repo_settings_dao = RepositorySettingsStore::new(db.connection());
                 let coderabbit_round_dao = CodeRabbitRoundStore::new(db.connection());
+                let coderabbit_comment_dao = CodeRabbitCommentStore::new(db.connection());
                 let coderabbit_item_dao = CodeRabbitItemStore::new(db.connection());
                 (
                     Some(repo_dao),
@@ -239,12 +241,13 @@ impl App {
                     Some(fork_seed_dao),
                     Some(repo_settings_dao),
                     Some(coderabbit_round_dao),
+                    Some(coderabbit_comment_dao),
                     Some(coderabbit_item_dao),
                 )
             }
             Err(e) => {
                 eprintln!("Warning: Failed to open database: {}", e);
-                (None, None, None, None, None, None, None, None)
+                (None, None, None, None, None, None, None, None, None)
             }
         };
 
@@ -290,6 +293,7 @@ impl App {
             workspace_dao.clone(),
             repo_settings_dao.clone(),
             coderabbit_round_dao.clone(),
+            coderabbit_comment_dao.clone(),
             coderabbit_item_dao.clone(),
         ) {
             (
@@ -297,12 +301,14 @@ impl App {
                 Some(workspace_dao),
                 Some(repo_settings_dao),
                 Some(coderabbit_round_dao),
+                Some(coderabbit_comment_dao),
                 Some(coderabbit_item_dao),
             ) => Some(CodeRabbitProcessor::new(
                 repo_dao,
                 workspace_dao,
                 repo_settings_dao,
                 coderabbit_round_dao,
+                coderabbit_comment_dao,
                 coderabbit_item_dao,
             )),
             _ => None,

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -3287,7 +3287,7 @@ impl App {
 
         if let Some(ConfirmationContext::CodeRabbitEnqueue { round_id }) = &ctx {
             self.state.pending_coderabbit_send = None;
-            self.mark_coderabbit_round_processed(round_id.clone());
+            self.mark_coderabbit_round_processed(*round_id);
         }
 
         self.state.confirmation_dialog_state.hide();

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -8566,6 +8566,7 @@ mod tests {
             app_state_dao: None,
             session_tab_dao: None,
             fork_seed_dao: None,
+            coderabbit_processor: None,
             worktree_manager: WorktreeManager::new(),
             git_tracker: None,
         }

--- a/src/ui/app/app_actions_coderabbit.rs
+++ b/src/ui/app/app_actions_coderabbit.rs
@@ -1,0 +1,27 @@
+use crate::ui::action::Action;
+use crate::ui::app::App;
+use crate::ui::events::InputMode;
+
+impl App {
+    pub(super) fn handle_coderabbit_feedback_action(&mut self, action: Action) {
+        if self.state.input_mode != InputMode::CodeRabbitFeedback {
+            return;
+        }
+
+        match action {
+            Action::CodeRabbitToggleSelection => {
+                self.state.coderabbit_feedback_state.toggle_selected();
+            }
+            Action::CodeRabbitSelectAll => {
+                self.state.coderabbit_feedback_state.select_all_filtered();
+            }
+            Action::CodeRabbitSelectNone => {
+                self.state.coderabbit_feedback_state.clear_selection();
+            }
+            Action::CodeRabbitCycleFilter => {
+                self.state.coderabbit_feedback_state.cycle_filter();
+            }
+            _ => {}
+        }
+    }
+}

--- a/src/ui/app/app_actions_confirm.rs
+++ b/src/ui/app/app_actions_confirm.rs
@@ -128,6 +128,9 @@ impl App {
                     self.state.input_mode = InputMode::PickingProject;
                 }
             }
+            InputMode::CodeRabbitFeedback => {
+                effects.extend(self.submit_coderabbit_feedback()?);
+            }
             InputMode::Confirming => {
                 if self.state.confirmation_dialog_state.is_confirm_selected() {
                     if let Some(context) = self.state.confirmation_dialog_state.context.clone() {
@@ -181,6 +184,12 @@ impl App {
                                 {
                                     effects.push(effect);
                                 }
+                                return Ok(());
+                            }
+                            ConfirmationContext::CodeRabbitEnqueue { round_id } => {
+                                self.state.confirmation_dialog_state.hide();
+                                self.state.input_mode = InputMode::Normal;
+                                effects.extend(self.confirm_coderabbit_enqueue(round_id)?);
                                 return Ok(());
                             }
                         }

--- a/src/ui/app/app_actions_confirmation.rs
+++ b/src/ui/app/app_actions_confirmation.rs
@@ -60,6 +60,11 @@ impl App {
                                     effects.push(effect);
                                 }
                             }
+                            ConfirmationContext::CodeRabbitEnqueue { round_id } => {
+                                self.state.confirmation_dialog_state.hide();
+                                self.state.input_mode = InputMode::Normal;
+                                effects.extend(self.confirm_coderabbit_enqueue(round_id)?);
+                            }
                         }
                     }
                 }

--- a/src/ui/app/app_actions_dialog.rs
+++ b/src/ui/app/app_actions_dialog.rs
@@ -64,6 +64,10 @@ impl App {
                     self.state.command_palette_state.hide();
                     self.state.input_mode = InputMode::Normal;
                 }
+                InputMode::CodeRabbitFeedback => {
+                    self.state.coderabbit_feedback_state.hide();
+                    self.state.input_mode = InputMode::Normal;
+                }
                 InputMode::QueueEditing => {
                     self.close_queue_editor();
                 }

--- a/src/ui/app/app_actions_global.rs
+++ b/src/ui/app/app_actions_global.rs
@@ -203,6 +203,12 @@ impl App {
                     );
                 }
             }
+            Action::OpenCodeRabbitFeedback => {
+                self.open_coderabbit_feedback();
+            }
+            Action::ToggleReviewLoop => {
+                self.toggle_review_loop();
+            }
             _ => {}
         }
     }

--- a/src/ui/app/app_actions_list.rs
+++ b/src/ui/app/app_actions_list.rs
@@ -36,6 +36,9 @@ impl App {
                         session.select_queue_next();
                     }
                 }
+                InputMode::CodeRabbitFeedback => {
+                    self.state.coderabbit_feedback_state.list.select_next();
+                }
                 _ => {}
             },
             Action::SelectPrev => match self.state.input_mode {
@@ -69,6 +72,9 @@ impl App {
                         session.select_queue_prev();
                     }
                 }
+                InputMode::CodeRabbitFeedback => {
+                    self.state.coderabbit_feedback_state.list.select_prev();
+                }
                 _ => {}
             },
             Action::SelectPageDown => {
@@ -76,6 +82,8 @@ impl App {
                     self.state.project_picker_state.page_down();
                 } else if self.state.input_mode == InputMode::ImportingSession {
                     self.state.session_import_state.page_down();
+                } else if self.state.input_mode == InputMode::CodeRabbitFeedback {
+                    self.state.coderabbit_feedback_state.list.page_down();
                 }
             }
             Action::SelectPageUp => {
@@ -83,6 +91,8 @@ impl App {
                     self.state.project_picker_state.page_up();
                 } else if self.state.input_mode == InputMode::ImportingSession {
                     self.state.session_import_state.page_up();
+                } else if self.state.input_mode == InputMode::CodeRabbitFeedback {
+                    self.state.coderabbit_feedback_state.list.page_up();
                 }
             }
             _ => {}

--- a/src/ui/app/app_scroll.rs
+++ b/src/ui/app/app_scroll.rs
@@ -27,6 +27,8 @@ impl App {
                 && self.state.theme_picker_state.is_visible())
             && !(self.state.input_mode == InputMode::SelectingModel
                 && self.state.model_selector_state.is_visible())
+            && !(self.state.input_mode == InputMode::CodeRabbitFeedback
+                && self.state.coderabbit_feedback_state.is_visible())
     }
 
     pub(super) fn raw_events_list_visible_height(&self) -> usize {
@@ -96,6 +98,15 @@ impl App {
             }
             for _ in 0..*pending_down {
                 self.state.theme_picker_state.select_next();
+            }
+        } else if self.state.input_mode == InputMode::CodeRabbitFeedback
+            && self.state.coderabbit_feedback_state.is_visible()
+        {
+            for _ in 0..*pending_up {
+                self.state.coderabbit_feedback_state.list.select_prev();
+            }
+            for _ in 0..*pending_down {
+                self.state.coderabbit_feedback_state.list.select_next();
             }
         } else if self.state.view_mode == ViewMode::RawEvents {
             let list_height = self.raw_events_list_visible_height();

--- a/src/ui/components/coderabbit_feedback_picker.rs
+++ b/src/ui/components/coderabbit_feedback_picker.rs
@@ -1,0 +1,434 @@
+//! CodeRabbit feedback picker dialog component
+
+use std::collections::HashSet;
+
+use ratatui::{
+    buffer::Buffer,
+    layout::Rect,
+    style::Style,
+    text::Line,
+    widgets::{Paragraph, Widget},
+};
+use unicode_width::UnicodeWidthStr;
+use uuid::Uuid;
+
+use crate::data::{CodeRabbitItem, CodeRabbitItemKind, CodeRabbitItemSource};
+
+use super::{
+    dialog_bg, dialog_content_area, ensure_contrast_bg, ensure_contrast_fg,
+    render_minimal_scrollbar, selected_bg, text_muted, text_primary, DialogFrame, ScrollbarMetrics,
+};
+
+const DIALOG_WIDTH_PERCENT: u16 = 80;
+const DIALOG_HEIGHT_PERCENT: u16 = 75;
+const DIALOG_MIN_WIDTH: u16 = 60;
+const DIALOG_MAX_WIDTH: u16 = 120;
+const DIALOG_MIN_HEIGHT: u16 = 15;
+const DIALOG_MAX_HEIGHT: u16 = 40;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CodeRabbitFeedbackFilter {
+    All,
+    Actionable,
+    Nitpick,
+    OutsideDiff,
+}
+
+impl CodeRabbitFeedbackFilter {
+    pub fn next(self) -> Self {
+        match self {
+            CodeRabbitFeedbackFilter::All => CodeRabbitFeedbackFilter::Actionable,
+            CodeRabbitFeedbackFilter::Actionable => CodeRabbitFeedbackFilter::Nitpick,
+            CodeRabbitFeedbackFilter::Nitpick => CodeRabbitFeedbackFilter::OutsideDiff,
+            CodeRabbitFeedbackFilter::OutsideDiff => CodeRabbitFeedbackFilter::All,
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            CodeRabbitFeedbackFilter::All => "All",
+            CodeRabbitFeedbackFilter::Actionable => "Actionable",
+            CodeRabbitFeedbackFilter::Nitpick => "Nitpicks",
+            CodeRabbitFeedbackFilter::OutsideDiff => "Outside diff",
+        }
+    }
+
+    pub fn matches(self, item: &CodeRabbitItem) -> bool {
+        match self {
+            CodeRabbitFeedbackFilter::All => true,
+            CodeRabbitFeedbackFilter::Actionable => item.kind == CodeRabbitItemKind::Actionable,
+            CodeRabbitFeedbackFilter::Nitpick => item.kind == CodeRabbitItemKind::Nitpick,
+            CodeRabbitFeedbackFilter::OutsideDiff => item.kind == CodeRabbitItemKind::OutsideDiff,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CodeRabbitFeedbackPickerState {
+    pub visible: bool,
+    pub round_id: Option<Uuid>,
+    pub pr_number: Option<i64>,
+    pub head_sha: Option<String>,
+    pub items: Vec<CodeRabbitItem>,
+    pub list: super::SearchableListState,
+    pub selected: HashSet<usize>,
+    pub filter: CodeRabbitFeedbackFilter,
+}
+
+impl CodeRabbitFeedbackPickerState {
+    pub fn new() -> Self {
+        Self {
+            visible: false,
+            round_id: None,
+            pr_number: None,
+            head_sha: None,
+            items: Vec::new(),
+            list: super::SearchableListState::new(12),
+            selected: HashSet::new(),
+            filter: CodeRabbitFeedbackFilter::All,
+        }
+    }
+
+    pub fn is_visible(&self) -> bool {
+        self.visible
+    }
+
+    pub fn show(
+        &mut self,
+        round_id: Uuid,
+        pr_number: i64,
+        head_sha: String,
+        items: Vec<CodeRabbitItem>,
+    ) {
+        self.visible = true;
+        self.round_id = Some(round_id);
+        self.pr_number = Some(pr_number);
+        self.head_sha = Some(head_sha);
+        self.items = items;
+        self.filter = CodeRabbitFeedbackFilter::All;
+        self.list.reset();
+        self.selected.clear();
+        for idx in 0..self.items.len() {
+            self.selected.insert(idx);
+        }
+        self.apply_filter();
+    }
+
+    pub fn hide(&mut self) {
+        self.visible = false;
+        self.round_id = None;
+        self.pr_number = None;
+        self.head_sha = None;
+        self.items.clear();
+        self.selected.clear();
+        self.list.reset();
+    }
+
+    pub fn apply_filter(&mut self) {
+        let filtered = self
+            .items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| self.filter.matches(item))
+            .map(|(idx, _)| idx)
+            .collect::<Vec<_>>();
+        self.list.set_filtered(filtered);
+    }
+
+    pub fn cycle_filter(&mut self) {
+        self.filter = self.filter.next();
+        self.apply_filter();
+    }
+
+    pub fn toggle_selected(&mut self) {
+        if let Some(item_idx) = self.selected_item_index() {
+            if self.selected.contains(&item_idx) {
+                self.selected.remove(&item_idx);
+            } else {
+                self.selected.insert(item_idx);
+            }
+        }
+    }
+
+    pub fn select_all_filtered(&mut self) {
+        for idx in &self.list.filtered {
+            self.selected.insert(*idx);
+        }
+    }
+
+    pub fn clear_selection(&mut self) {
+        self.selected.clear();
+    }
+
+    pub fn selected_count(&self) -> usize {
+        self.selected.len()
+    }
+
+    pub fn selected_item_index(&self) -> Option<usize> {
+        if self.list.filtered.is_empty() {
+            None
+        } else {
+            Some(self.list.filtered[self.list.selected])
+        }
+    }
+
+    pub fn selected_items(&self) -> Vec<CodeRabbitItem> {
+        let mut items = Vec::new();
+        for (idx, item) in self.items.iter().enumerate() {
+            if self.selected.contains(&idx) {
+                items.push(item.clone());
+            }
+        }
+        items
+    }
+}
+
+impl Default for CodeRabbitFeedbackPickerState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PickerLayout {
+    header_area: Rect,
+    list_area: Rect,
+    scrollbar_area: Rect,
+}
+
+fn calculate_layout(area: Rect, visible_rows: usize) -> Option<(Rect, PickerLayout)> {
+    let dialog_width = (area.width * DIALOG_WIDTH_PERCENT / 100)
+        .clamp(DIALOG_MIN_WIDTH, DIALOG_MAX_WIDTH)
+        .min(area.width.saturating_sub(4));
+    let dialog_height = (area.height * DIALOG_HEIGHT_PERCENT / 100)
+        .clamp(DIALOG_MIN_HEIGHT, DIALOG_MAX_HEIGHT)
+        .min(area.height.saturating_sub(2));
+
+    let dialog_x = area.width.saturating_sub(dialog_width) / 2;
+    let dialog_y = area.height.saturating_sub(dialog_height) / 2;
+
+    let dialog_area = Rect {
+        x: dialog_x,
+        y: dialog_y,
+        width: dialog_width,
+        height: dialog_height,
+    };
+
+    let inner = dialog_content_area(dialog_area);
+    if inner.height < 2 || inner.width < 10 {
+        return None;
+    }
+
+    let header_area = Rect {
+        x: inner.x,
+        y: inner.y,
+        width: inner.width,
+        height: 1,
+    };
+
+    let list_height = inner.height.saturating_sub(1);
+    if list_height == 0 {
+        return None;
+    }
+
+    let list_area = Rect {
+        x: inner.x,
+        y: inner.y + 1,
+        width: inner.width.saturating_sub(1),
+        height: list_height,
+    };
+
+    let scrollbar_area = Rect {
+        x: inner.x + inner.width.saturating_sub(1),
+        y: inner.y + 1,
+        width: 1,
+        height: list_height,
+    };
+
+    let max_visible = visible_rows.min(list_height as usize).max(1);
+    Some((
+        dialog_area,
+        PickerLayout {
+            header_area,
+            list_area: Rect {
+                height: max_visible as u16,
+                ..list_area
+            },
+            scrollbar_area,
+        },
+    ))
+}
+
+pub struct CodeRabbitFeedbackPicker;
+
+impl CodeRabbitFeedbackPicker {
+    pub fn render(&self, area: Rect, buf: &mut Buffer, state: &CodeRabbitFeedbackPickerState) {
+        if !state.visible {
+            return;
+        }
+
+        let instructions = vec![
+            ("Space", "toggle"),
+            ("A", "all"),
+            ("N", "none"),
+            ("F", "filter"),
+            ("Enter", "send"),
+            ("Esc", "close"),
+        ];
+        let dialog = DialogFrame::new("CodeRabbit Feedback", 0, 0).instructions(instructions);
+
+        let max_visible = state.list.max_visible;
+        let Some((dialog_area, layout)) = calculate_layout(area, max_visible) else {
+            return;
+        };
+
+        dialog.render(dialog_area, buf);
+
+        let total = state.items.len();
+        let selected = state.selected_count();
+        let pr_label = state
+            .pr_number
+            .map(|num| format!("PR #{}", num))
+            .unwrap_or_else(|| "PR".to_string());
+        let header_text = format!(
+            "{} | Filter: {} | Selected: {}/{}",
+            pr_label,
+            state.filter.label(),
+            selected,
+            total
+        );
+        Paragraph::new(header_text)
+            .style(Style::default().fg(text_primary()).bg(dialog_bg()))
+            .render(layout.header_area, buf);
+
+        let mut lines = Vec::new();
+        let start = state.list.scroll_offset;
+        let end = (start + state.list.max_visible).min(state.list.filtered.len());
+        let visible_indices = &state.list.filtered[start..end];
+
+        for (row, item_idx) in visible_indices.iter().enumerate() {
+            let item = &state.items[*item_idx];
+            let selected_mark = if state.selected.contains(item_idx) {
+                "[x]"
+            } else {
+                "[ ]"
+            };
+            let kind_label = match item.kind {
+                CodeRabbitItemKind::Actionable => "A",
+                CodeRabbitItemKind::Nitpick => "N",
+                CodeRabbitItemKind::OutsideDiff => "O",
+            };
+            let location = format_location(item);
+            let summary = summarize_body(&item.body);
+            let mut line = format!(
+                "{} {} {} - {}",
+                selected_mark, kind_label, location, summary
+            );
+            let max_width = layout.list_area.width as usize;
+            if max_width > 0 {
+                line = truncate_to_width(&line, max_width);
+            }
+
+            let is_selected = state.list.selected == start + row;
+            let row_style = if is_selected {
+                let bg = ensure_contrast_bg(selected_bg(), dialog_bg(), 1.3);
+                Style::default()
+                    .bg(bg)
+                    .fg(ensure_contrast_fg(text_primary(), bg, 4.5))
+            } else {
+                Style::default().fg(text_primary()).bg(dialog_bg())
+            };
+            lines.push(Line::styled(line, row_style));
+        }
+
+        let list_widget = Paragraph::new(lines).style(Style::default().bg(dialog_bg()));
+        list_widget.render(layout.list_area, buf);
+
+        let scrollbar_metrics = ScrollbarMetrics {
+            area: layout.scrollbar_area,
+            total: state.list.filtered.len(),
+            visible: state.list.max_visible,
+        };
+        if scrollbar_metrics.area.height > 0 {
+            render_minimal_scrollbar(
+                scrollbar_metrics.area,
+                buf,
+                scrollbar_metrics.total.max(1),
+                scrollbar_metrics.visible,
+                state.list.scroll_offset,
+            );
+        }
+
+        if state.items.is_empty() {
+            let empty_msg = Paragraph::new("No CodeRabbit feedback items.")
+                .style(Style::default().fg(text_muted()).bg(dialog_bg()));
+            empty_msg.render(layout.list_area, buf);
+        }
+    }
+}
+
+fn format_location(item: &CodeRabbitItem) -> String {
+    if let Some(path) = item.file_path.as_ref() {
+        let mut location = path.clone();
+        if let Some(line_start) = item.line_start {
+            if let Some(line_end) = item.line_end {
+                if line_end != line_start {
+                    location.push_str(&format!(":{}-{}", line_start, line_end));
+                } else {
+                    location.push_str(&format!(":{}", line_start));
+                }
+            } else {
+                location.push_str(&format!(":{}", line_start));
+            }
+        }
+        return location;
+    }
+    if let Some(section) = item.section.as_ref() {
+        return section.clone();
+    }
+    format_source(item.source)
+}
+
+fn format_source(source: CodeRabbitItemSource) -> String {
+    match source {
+        CodeRabbitItemSource::ReviewComment => "review-comment".to_string(),
+        CodeRabbitItemSource::IssueComment => "issue-comment".to_string(),
+        CodeRabbitItemSource::Review => "review".to_string(),
+    }
+}
+
+fn summarize_body(body: &str) -> String {
+    let line = body
+        .lines()
+        .find(|line| !line.trim().is_empty())
+        .unwrap_or("")
+        .trim();
+    if line.is_empty() {
+        "<no comment>".to_string()
+    } else {
+        line.to_string()
+    }
+}
+
+fn truncate_to_width(s: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return String::new();
+    }
+    if UnicodeWidthStr::width(s) <= max_width {
+        return s.to_string();
+    }
+    let mut result = String::new();
+    let mut width = 0usize;
+    for ch in s.chars() {
+        let ch_width = UnicodeWidthStr::width(ch.to_string().as_str());
+        if width + ch_width >= max_width.saturating_sub(1) {
+            break;
+        }
+        result.push(ch);
+        width += ch_width;
+    }
+    if max_width > 3 {
+        result.push_str("...");
+    }
+    result
+}

--- a/src/ui/components/command_palette.rs
+++ b/src/ui/components/command_palette.rs
@@ -115,6 +115,8 @@ impl CommandPaletteState {
             Action::ToggleMetrics,
             Action::DumpDebugState,
             Action::OpenQueueEditor,
+            Action::OpenCodeRabbitFeedback,
+            Action::ToggleReviewLoop,
             Action::CloseTab,
             Action::NextTab,
             Action::PrevTab,

--- a/src/ui/components/confirmation_dialog.rs
+++ b/src/ui/components/confirmation_dialog.rs
@@ -52,6 +52,8 @@ pub enum ConfirmationContext {
         /// The branch to fork from (computed at dialog show time for consistency)
         base_branch: String,
     },
+    /// Queue CodeRabbit feedback while agent is busy
+    CodeRabbitEnqueue { round_id: Uuid },
 }
 
 impl ConfirmationType {

--- a/src/ui/components/mod.rs
+++ b/src/ui/components/mod.rs
@@ -3,6 +3,7 @@ mod agent_selector;
 mod base_dir_dialog;
 mod chat_message;
 mod chat_view;
+mod coderabbit_feedback_picker;
 mod command_palette;
 mod confirmation_dialog;
 mod dialog;
@@ -41,6 +42,9 @@ pub use agent_selector::{AgentSelector, AgentSelectorState};
 pub use base_dir_dialog::{BaseDirDialog, BaseDirDialogState};
 pub use chat_message::{ChatMessage, MessageRole};
 pub use chat_view::ChatView;
+pub use coderabbit_feedback_picker::{
+    CodeRabbitFeedbackFilter, CodeRabbitFeedbackPicker, CodeRabbitFeedbackPickerState,
+};
 pub use command_palette::{CommandPalette, CommandPaletteEntry, CommandPaletteState};
 pub use confirmation_dialog::{
     ConfirmationContext, ConfirmationDialog, ConfirmationDialogState, ConfirmationType,

--- a/src/ui/events.rs
+++ b/src/ui/events.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use crate::agent::{AgentEvent, AgentInput, AgentType};
+use crate::data::CodeRabbitRound;
 use crate::git::PrPreflightResult;
 use crate::ui::git_tracker::GitTrackerUpdate;
 use tokio::sync::mpsc;
@@ -122,6 +123,9 @@ pub enum AppEvent {
     /// Git tracker update (PR status, git stats, branch changes)
     GitTracker(GitTrackerUpdate),
 
+    /// CodeRabbit round updated after fetch
+    CodeRabbitRoundUpdated { round: CodeRabbitRound },
+
     /// Title/branch generation completed
     TitleGenerated {
         /// Stable session ID for correlation (avoids stale tab_index after close/reorder)
@@ -221,6 +225,8 @@ pub enum InputMode {
     CommandPalette,
     /// Missing tool dialog is open
     MissingTool,
+    /// Reviewing CodeRabbit feedback
+    CodeRabbitFeedback,
     /// Editing queued messages inline
     QueueEditing,
 }


### PR DESCRIPTION
Detect CodeRabbit check completion and fetch actionable review items. Store rounds and items in the DB with retry/backoff and cleanup support. Add parsing helpers to satisfy clippy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CodeRabbit integration: detect PR check completions, surface per-check metadata/head SHA, fetch/group actionable items, run background processing, retry and cleanup flows.
  * Feedback UI: interactive CodeRabbit feedback picker, keyboard context and keybindings, actions to open/select/enqueue/send feedback, and UI event/notification plumbing.

* **Chores**
  * Database schema and persistence for CodeRabbit rounds, items, comments, and repository settings added.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->