### PR TITLE
fix: clippy unnecessary_unwrap in TUI chat view

### DIFF
--- a/src/ui/components/chat_view.rs
+++ b/src/ui/components/chat_view.rs
@@ -571,10 +571,12 @@ impl ChatView {
         }
 
         // Update previous message's spacing if needed (it may have changed)
-        if !self.messages.is_empty() && self.cache_width.is_some() {
-            let prev_idx = self.messages.len() - 1;
-            self.invalidate_cache_entry(prev_idx);
-            self.update_cache_entry(prev_idx, self.cache_width.unwrap());
+        if !self.messages.is_empty() {
+            if let Some(width) = self.cache_width {
+                let prev_idx = self.messages.len() - 1;
+                self.invalidate_cache_entry(prev_idx);
+                self.update_cache_entry(prev_idx, width);
+            }
         }
 
         self.messages.push(message);
@@ -667,10 +669,12 @@ impl ChatView {
             self.streaming_joiner_before = None;
 
             // Update previous message's spacing if needed
-            if !self.messages.is_empty() && self.cache_width.is_some() {
-                let prev_idx = self.messages.len() - 1;
-                self.invalidate_cache_entry(prev_idx);
-                self.update_cache_entry(prev_idx, self.cache_width.unwrap());
+            if !self.messages.is_empty() {
+                if let Some(width) = self.cache_width {
+                    let prev_idx = self.messages.len() - 1;
+                    self.invalidate_cache_entry(prev_idx);
+                    self.update_cache_entry(prev_idx, width);
+                }
             }
 
             self.messages.push(ChatMessage::assistant(content));


### PR DESCRIPTION
Fixes CI clippy failure (run 21251129825) by avoiding unwrap() on cache_width after an is_some() check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache refresh logic to conditionally update message cache entries only when cache width is available, eliminating unnecessary cache operations during message handling and streaming operations, enhancing performance and reducing redundant processing overhead throughout the chat user interface.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->