### PR TITLE
feat(web): add progress and unseen indicators to session tabs

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,6 +38,7 @@ import {
   useUpdateRepositorySettings,
   useWorkspaceActions,
   useUpdateSession,
+  useClearUnseenSession,
 } from './hooks';
 import type { Repository, Workspace, Session, SessionEvent, AgentEvent, WorkspaceMode } from './types';
 
@@ -122,6 +123,7 @@ function AppContent() {
   const { data: uiState } = useUiState({ enabled: !!bootstrap });
   const updateUiState = useUpdateUiState();
   const closeSession = useCloseSession();
+  const clearUnseenSession = useClearUnseenSession();
   const archiveWorkspace = useArchiveWorkspace();
   const autoCreateWorkspace = useAutoCreateWorkspace();
   const updateRepositorySettings = useUpdateRepositorySettings();
@@ -269,6 +271,13 @@ function AppContent() {
     if (!activeSessionId || resolvedUiState?.active_session_id === activeSessionId) return;
     updateUiState.mutate({ active_session_id: activeSessionId });
   }, [activeSessionId, resolvedUiState?.active_session_id, updateUiState]);
+
+  // Clear unseen indicator when switching to a session
+  useEffect(() => {
+    if (activeSessionId) {
+      clearUnseenSession(activeSessionId);
+    }
+  }, [activeSessionId, clearUnseenSession]);
 
   useEffect(() => {
     if (!activeSessionId) {


### PR DESCRIPTION
## Summary
- Adds a spinning amber indicator to tabs when a session is actively processing
- Shows a green dot on background tabs that have new content not yet viewed
- Indicators use priority-based rendering: processing > unseen > agent type dot

## Test plan
- [ ] Start a long-running agent task and verify spinner appears on the tab
- [ ] Switch away from a tab while it's processing, verify green dot appears when it completes
- [ ] Switch to a tab with a green dot and verify it disappears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual indicators to session tabs displaying processing status and unseen content markers.
  * Unseen content badges on tabs are automatically cleared when switching to that session.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->