### PR TITLE
feat(web): paste images from clipboard into chat input

### DIFF
--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -147,6 +147,17 @@ export function ChatInput({
     fileInputRef.current?.click();
   };
 
+  const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!onAttachImages) return;
+    const files = Array.from(e.clipboardData.files).filter((f) =>
+      f.type.startsWith('image/')
+    );
+    if (files.length > 0) {
+      e.preventDefault();
+      onAttachImages(files);
+    }
+  };
+
   const handleFilesSelected = (files: FileList | null) => {
     if (!files || !onAttachImages) return;
     const nextFiles = Array.from(files);
@@ -239,6 +250,7 @@ export function ChatInput({
             value={value}
             onChange={(e) => onChange(e.target.value)}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             data-chat-input="true"
             placeholder={placeholder}
             disabled={effectiveInputDisabled}


### PR DESCRIPTION
## Summary

- Adds an `onPaste` handler to the chat textarea in `ChatInput.tsx`
- When the clipboard contains image files (e.g. a screenshot), they are extracted and passed to the existing `onAttachImages` pipeline
- If no images are in the clipboard, the paste event falls through normally so text paste is unaffected

## No backend changes needed

The entire image pipeline already exists — `onAttachImages` encodes files as base64 data URLs, sends them over WebSocket, and the backend decodes and forwards them to the LLM.

## Test plan

- [x] Copy a screenshot to the clipboard, click in the chat input, Ctrl+V — image thumbnail appears in the attachment strip
- [x] Type text and Ctrl+V with text on clipboard — text pastes normally, no image attachment created
- [x] Attach image via paste and send — image arrives at the LLM

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now paste images directly into the chat input from their clipboard. When images are detected in clipboard content, they're automatically extracted and attached to messages. Non-image content continues to paste normally, integrating seamlessly with existing attachment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->