### PR TITLE
fix(tui): remove sidebar from Alt+Tab workspace cycle

### DIFF
--- a/src/ui/app/app_actions_tabs.rs
+++ b/src/ui/app/app_actions_tabs.rs
@@ -47,7 +47,6 @@ impl App {
                 effects.push(Effect::SaveSessionState);
             }
             Action::NextTab => {
-                // Include sidebar in tab cycle when visible
                 if self.state.input_mode == InputMode::SidebarNavigation {
                     // From sidebar, go to first tab
                     if !self.state.tab_manager.is_empty() {
@@ -57,21 +56,8 @@ impl App {
                         self.sync_input_mode_for_active_tab();
                         self.sync_sidebar_to_active_tab();
                     }
-                } else if self.state.sidebar_state.visible {
-                    // Check if on last tab - if so, go to sidebar
-                    let current = self.state.tab_manager.active_index();
-                    let count = self.state.tab_manager.len();
-                    if count > 0 && current == count - 1 {
-                        // On last tab, go to sidebar
-                        self.state.sidebar_state.set_focused(true);
-                        self.state.input_mode = InputMode::SidebarNavigation;
-                    } else {
-                        self.state.tab_manager.next_tab();
-                        self.sync_input_mode_for_active_tab();
-                        self.sync_sidebar_to_active_tab();
-                        self.sync_footer_spinner();
-                    }
                 } else {
+                    // Cycle through workspaces, wrapping around (sidebar not in cycle)
                     self.state.tab_manager.next_tab();
                     self.sync_input_mode_for_active_tab();
                     self.sync_sidebar_to_active_tab();
@@ -79,7 +65,6 @@ impl App {
                 }
             }
             Action::PrevTab => {
-                // Include sidebar in tab cycle when visible
                 if self.state.input_mode == InputMode::SidebarNavigation {
                     // From sidebar, go to last tab
                     let count = self.state.tab_manager.len();
@@ -91,20 +76,8 @@ impl App {
                         self.sync_sidebar_to_active_tab();
                         self.sync_footer_spinner();
                     }
-                } else if self.state.sidebar_state.visible {
-                    // Check if on first tab - if so, go to sidebar
-                    let current = self.state.tab_manager.active_index();
-                    if current == 0 {
-                        // On first tab, go to sidebar
-                        self.state.sidebar_state.set_focused(true);
-                        self.state.input_mode = InputMode::SidebarNavigation;
-                    } else {
-                        self.state.tab_manager.prev_tab();
-                        self.sync_input_mode_for_active_tab();
-                        self.sync_sidebar_to_active_tab();
-                        self.sync_footer_spinner();
-                    }
                 } else {
+                    // Cycle through workspaces in reverse, wrapping around (sidebar not in cycle)
                     self.state.tab_manager.prev_tab();
                     self.sync_input_mode_for_active_tab();
                     self.sync_sidebar_to_active_tab();


### PR DESCRIPTION
## Summary

- `Alt+Tab` and `Alt+Shift+Tab` now cycle purely through workspaces, wrapping from last→first and first→last respectively
- Removes the sidebar as a stop in the workspace cycle — pressing `Alt+Tab` from the last workspace now wraps directly to the first, and `Alt+Shift+Tab` from the first workspace wraps directly to the last
- When the sidebar is already focused, `Alt+Tab`/`Alt+Shift+Tab` still exits to the first/last workspace as before

## Background

`Option+Tab` was working for forward cycling but `Option+Shift+Tab` appeared not to cycle back. The key event was being received correctly (`BackTab + Shift+Alt` via Kitty keyboard protocol), and the global binding `BackTab+ALT|SHIFT → PrevTab` was present. The actual issue was behavioral: `PrevTab` from the first workspace diverted to the sidebar rather than wrapping to the last workspace, making it feel like backward cycling was broken.

## Test plan

- [ ] `Alt+Tab` cycles forward through all workspaces, wrapping from last back to first (no sidebar stop)
- [ ] `Alt+Shift+Tab` cycles backward through all workspaces, wrapping from first back to last (no sidebar stop)
- [ ] When sidebar is focused, `Alt+Tab` goes to first workspace and `Alt+Shift+Tab` goes to last workspace
- [ ] `Ctrl+T` still toggles the sidebar independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified tab navigation behavior. `Next Tab` and `Prev Tab` actions now consistently cycle through tabs with wraparound, removing conditional logic that previously switched focus to the sidebar at tab boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->