### PR TITLE
feat(tui): add Alt+y global hotkey to copy nearest code block

### DIFF
--- a/src/config/default_keys.rs
+++ b/src/config/default_keys.rs
@@ -238,6 +238,7 @@ pub fn default_keybindings() -> KeybindingConfig {
     );
     bind(scrolling, "q", Action::Cancel);
     bind(scrolling, "i", Action::Cancel);
+    bind(scrolling, "y", Action::CopyCodeBlock);
 
     // ========== File Viewer ==========
     let file_viewer = config.context.entry(KeyContext::FileViewer).or_default();

--- a/src/config/default_keys.rs
+++ b/src/config/default_keys.rs
@@ -100,6 +100,8 @@ pub fn default_keybindings() -> KeybindingConfig {
     bind(&mut config.global, "M-S-c", Action::CopyWorkspacePath);
     // Copy selection to clipboard
     bind(&mut config.global, "M-c", Action::CopySelection);
+    // Copy nearest visible code block to clipboard
+    bind(&mut config.global, "M-y", Action::CopyCodeBlock);
 
     // Ctrl+Arrow for scrolling
     config.global.insert(

--- a/src/ui/action.rs
+++ b/src/ui/action.rs
@@ -48,6 +48,8 @@ pub enum Action {
     CopyWorkspacePath,
     /// Copy active selection to clipboard
     CopySelection,
+    /// Copy the bottommost visible code block to clipboard (dedented)
+    CopyCodeBlock,
 
     // ========== Tab Management ==========
     /// Close current tab
@@ -255,6 +257,7 @@ impl Action {
             Action::Suspend => "Suspend",
             Action::CopyWorkspacePath => "Copy workspace path",
             Action::CopySelection => "Copy selection",
+            Action::CopyCodeBlock => "Copy code block",
 
             // Tab management
             Action::CloseTab => "Close tab",
@@ -404,6 +407,7 @@ impl Action {
                 | Action::DumpDebugState
                 | Action::CopyWorkspacePath
                 | Action::CopySelection
+                | Action::CopyCodeBlock
                 // Tab management
                 | Action::CloseTab
                 | Action::NextTab

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1794,7 +1794,8 @@ impl App {
             | Action::ToggleAgentMode
             | Action::DumpDebugState
             | Action::CopyWorkspacePath
-            | Action::CopySelection => {
+            | Action::CopySelection
+            | Action::CopyCodeBlock => {
                 self.handle_global_action(action, &mut effects);
             }
             Action::OpenPr => {
@@ -2938,13 +2939,22 @@ impl App {
                     use arboard::Clipboard;
                     match Clipboard::new() {
                         Ok(mut clipboard) => {
-                            if let Err(e) = clipboard.set_text(text) {
+                            if let Err(e) = clipboard.set_text(&text) {
                                 tracing::debug!(error = %e, "Failed to copy text to clipboard");
                             }
                         }
                         Err(e) => {
                             tracing::debug!(error = %e, "Failed to initialize clipboard");
                         }
+                    }
+                    // Also emit OSC 52 so the clipboard is set on the SSH client terminal.
+                    // Requires tmux: set -g set-clipboard on
+                    {
+                        use base64::Engine as _;
+                        let encoded =
+                            base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
+                        let osc52 = format!("\x1b]52;c;{}\x07", encoded);
+                        let _ = std::io::Write::write_all(&mut std::io::stdout(), osc52.as_bytes());
                     }
                 }
                 Effect::DiscoverSessions => {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use anyhow::anyhow;
 use chrono::Utc;
 use crossterm::{
-    event::{EnableMouseCapture, Event, EventStream, KeyCode, KeyModifiers, MouseEventKind},
+    event::{EnableBracketedPaste, EnableMouseCapture, Event, EventStream, KeyCode, KeyModifiers, MouseEventKind},
     execute,
     terminal::{enable_raw_mode, EnterAlternateScreen},
 };
@@ -972,7 +972,7 @@ impl App {
         // Create terminal guard AFTER enabling features - Drop will clean up on any exit path
         let mut guard = TerminalGuard::new(keyboard_enhancement_enabled);
 
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture, EnableBracketedPaste)?;
 
         let backend = CrosstermBackend::new(stdout);
         let mut terminal = Terminal::new(backend)?;
@@ -8610,7 +8610,7 @@ impl App {
     ) -> anyhow::Result<()> {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture, EnableBracketedPaste)?;
         terminal.clear()?;
         Ok(())
     }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -2442,6 +2442,11 @@ impl App {
                                 return Err(format!("Failed to save workspace to database: {}", e));
                             }
 
+                            crate::util::workspace_setup::run_workspace_setup_script(
+                                &base_path,
+                                &workspace.path,
+                            );
+
                             Ok(WorkspaceCreated {
                                 repo_id,
                                 workspace_id,
@@ -2550,6 +2555,11 @@ impl App {
                                 }
                                 return Err(format!("Failed to save workspace to database: {}", e));
                             }
+
+                            crate::util::workspace_setup::run_workspace_setup_script(
+                                &base_path,
+                                &workspace.path,
+                            );
 
                             Ok(ForkWorkspaceCreated {
                                 repo_id: parent_workspace.repository_id,

--- a/src/ui/app/app_actions_global.rs
+++ b/src/ui/app/app_actions_global.rs
@@ -255,6 +255,31 @@ impl App {
                     );
                 }
             }
+            Action::CopyCodeBlock => {
+                if let Some(session) = self.state.tab_manager.active_session_mut() {
+                    match session.chat_view.nearest_code_block_content() {
+                        Some((content, idx, total)) => {
+                            effects.push(Effect::CopyToClipboard(content));
+                            let msg = if total > 1 {
+                                format!(
+                                    "Copied code block ({} of {}) — scroll to copy others",
+                                    idx, total
+                                )
+                            } else {
+                                "Copied code block".to_string()
+                            };
+                            self.state
+                                .set_timed_footer_message(msg, Duration::from_secs(3));
+                        }
+                        None => {
+                            self.state.set_timed_footer_message(
+                                "No code block in view".to_string(),
+                                Duration::from_secs(2),
+                            );
+                        }
+                    }
+                }
+            }
             _ => {}
         }
     }

--- a/src/ui/app/app_actions_tabs.rs
+++ b/src/ui/app/app_actions_tabs.rs
@@ -47,7 +47,6 @@ impl App {
                 effects.push(Effect::SaveSessionState);
             }
             Action::NextTab => {
-                // Include sidebar in tab cycle when visible
                 if self.state.input_mode == InputMode::SidebarNavigation {
                     // From sidebar, go to first tab
                     if !self.state.tab_manager.is_empty() {
@@ -57,21 +56,8 @@ impl App {
                         self.sync_input_mode_for_active_tab();
                         self.sync_sidebar_to_active_tab();
                     }
-                } else if self.state.sidebar_state.visible {
-                    // Check if on last tab - if so, go to sidebar
-                    let current = self.state.tab_manager.active_index();
-                    let count = self.state.tab_manager.len();
-                    if count > 0 && current == count - 1 {
-                        // On last tab, go to sidebar
-                        self.state.sidebar_state.set_focused(true);
-                        self.state.input_mode = InputMode::SidebarNavigation;
-                    } else {
-                        self.state.tab_manager.next_tab();
-                        self.sync_input_mode_for_active_tab();
-                        self.sync_sidebar_to_active_tab();
-                        self.sync_footer_spinner();
-                    }
                 } else {
+                    // Cycle through workspaces, wrapping around (sidebar not in cycle)
                     self.state.tab_manager.next_tab();
                     self.sync_input_mode_for_active_tab();
                     self.sync_sidebar_to_active_tab();
@@ -79,7 +65,6 @@ impl App {
                 }
             }
             Action::PrevTab => {
-                // Include sidebar in tab cycle when visible
                 if self.state.input_mode == InputMode::SidebarNavigation {
                     // From sidebar, go to last tab
                     let count = self.state.tab_manager.len();
@@ -91,20 +76,8 @@ impl App {
                         self.sync_sidebar_to_active_tab();
                         self.sync_footer_spinner();
                     }
-                } else if self.state.sidebar_state.visible {
-                    // Check if on first tab - if so, go to sidebar
-                    let current = self.state.tab_manager.active_index();
-                    if current == 0 {
-                        // On first tab, go to sidebar
-                        self.state.sidebar_state.set_focused(true);
-                        self.state.input_mode = InputMode::SidebarNavigation;
-                    } else {
-                        self.state.tab_manager.prev_tab();
-                        self.sync_input_mode_for_active_tab();
-                        self.sync_sidebar_to_active_tab();
-                        self.sync_footer_spinner();
-                    }
                 } else {
+                    // Cycle through workspaces in reverse, wrapping around (sidebar not in cycle)
                     self.state.tab_manager.prev_tab();
                     self.sync_input_mode_for_active_tab();
                     self.sync_sidebar_to_active_tab();

--- a/src/ui/components/chat_view.rs
+++ b/src/ui/components/chat_view.rs
@@ -479,6 +479,10 @@ pub struct ChatView {
     last_extra_lines_start: usize,
     /// Label for the agent (e.g. "Claude", "Codex") shown above assistant messages
     agent_label: String,
+    /// Flat cache line span (start, end) for each line_cache entry, parallel to line_cache.entries
+    flat_cache_entry_spans: Vec<(usize, usize)>,
+    /// Viewport height from the last render pass (used by nearest_code_block_content)
+    last_visible_height: usize,
 }
 
 /// Information about a hovered file path for rendering
@@ -517,6 +521,8 @@ impl ChatView {
             last_extra_lines: Vec::new(),
             last_extra_lines_start: 0,
             agent_label: "Claude".to_string(),
+            flat_cache_entry_spans: Vec::new(),
+            last_visible_height: 0,
         }
     }
 
@@ -533,6 +539,52 @@ impl ChatView {
             self.streaming_joiner_before = None;
             self.cache_width = None;
         }
+    }
+
+    /// Return the dedented content of the bottommost visible code block.
+    ///
+    /// Returns `Some((content, block_index, total_blocks))` where `block_index` is
+    /// 1-based within visible blocks, or `None` if no code blocks are visible.
+    pub fn nearest_code_block_content(&self) -> Option<(String, usize, usize)> {
+        let bottom = self.flat_cache.len().saturating_sub(self.scroll_offset);
+        let top = bottom.saturating_sub(self.last_visible_height);
+
+        let mut visible_blocks: Vec<String> = Vec::new();
+        for (i, &(entry_start, entry_end)) in self.flat_cache_entry_spans.iter().enumerate() {
+            if entry_end <= top {
+                continue; // entirely above viewport
+            }
+            if entry_start >= bottom {
+                break; // entirely below viewport
+            }
+            if let Some(Some(entry)) = self.line_cache.entries.get(i) {
+                visible_blocks.extend(entry.code_blocks.iter().cloned());
+            }
+        }
+
+        let total = visible_blocks.len();
+        visible_blocks
+            .into_iter()
+            .last()
+            .map(|c| (Self::dedent(&c), total, total))
+    }
+
+    fn dedent(content: &str) -> String {
+        let lines: Vec<&str> = content.lines().collect();
+        let min_indent = lines
+            .iter()
+            .filter(|l| !l.trim().is_empty())
+            .map(|l| l.len() - l.trim_start_matches(' ').len())
+            .min()
+            .unwrap_or(0);
+        if min_indent == 0 {
+            return content.to_string();
+        }
+        lines
+            .iter()
+            .map(|l| l.get(min_indent..).unwrap_or(l))
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 
     /// Calculate content area with padding for left margin and optional scrollbar.
@@ -1489,19 +1541,35 @@ impl ChatView {
         width: usize,
         lines: &mut Vec<Line<'static>>,
         joiner_before: &mut Vec<Option<String>>,
-    ) {
+    ) -> Vec<String> {
         match msg.role {
-            MessageRole::Tool => self.format_tool_message(msg, width, lines, joiner_before),
-            MessageRole::User => self.format_user_message(msg, width, lines, joiner_before),
+            MessageRole::Tool => {
+                self.format_tool_message(msg, width, lines, joiner_before);
+                Vec::new()
+            }
+            MessageRole::User => {
+                self.format_user_message(msg, width, lines, joiner_before);
+                Vec::new()
+            }
             MessageRole::Assistant => {
                 self.format_assistant_message(msg, width, lines, joiner_before)
             }
             MessageRole::Reasoning => {
-                self.format_reasoning_message(msg, width, lines, joiner_before)
+                self.format_reasoning_message(msg, width, lines, joiner_before);
+                Vec::new()
             }
-            MessageRole::System => self.format_system_message(msg, width, lines, joiner_before),
-            MessageRole::Error => self.format_error_message(msg, width, lines, joiner_before),
-            MessageRole::Summary => self.format_summary_message(msg, width, lines, joiner_before),
+            MessageRole::System => {
+                self.format_system_message(msg, width, lines, joiner_before);
+                Vec::new()
+            }
+            MessageRole::Error => {
+                self.format_error_message(msg, width, lines, joiner_before);
+                Vec::new()
+            }
+            MessageRole::Summary => {
+                self.format_summary_message(msg, width, lines, joiner_before);
+                Vec::new()
+            }
         }
     }
 
@@ -1584,9 +1652,9 @@ impl ChatView {
         width: usize,
         lines: &mut Vec<Line<'static>>,
         joiner_before: &mut Vec<Option<String>>,
-    ) {
+    ) -> Vec<String> {
         if msg.content.is_empty() {
-            return;
+            return Vec::new();
         }
 
         // Vertical breathing room
@@ -1601,8 +1669,9 @@ impl ChatView {
         joiner_before.push(None);
 
         // Parse markdown with custom renderer
-        let renderer = MarkdownRenderer::new();
+        let mut renderer = MarkdownRenderer::new();
         let md_text = renderer.render(&msg.content);
+        let code_blocks = std::mem::take(&mut renderer.code_blocks);
 
         let bullet_prefix = vec![Span::raw("• ")];
         let continuation_prefix = vec![Span::raw("  ")];
@@ -1677,6 +1746,8 @@ impl ChatView {
             ]));
             joiner_before.push(None);
         }
+
+        code_blocks
     }
 
     /// Format reasoning messages with subdued styling
@@ -2340,6 +2411,7 @@ impl ChatView {
         self.last_extra_lines_start = cached_len + streaming_len;
         let total_lines = cached_len + streaming_len + extra_len;
         let visible_height = content.height as usize;
+        self.last_visible_height = visible_height;
 
         // Clamp scroll offset (respect selection lock if active)
         let max_scroll = total_lines.saturating_sub(visible_height);

--- a/src/ui/components/chat_view/chat_view_cache.rs
+++ b/src/ui/components/chat_view/chat_view_cache.rs
@@ -17,6 +17,8 @@ pub(super) struct CachedMessageLines {
     /// Hash of message content for invalidation detection (reserved for future use)
     #[allow(dead_code)]
     pub(super) content_hash: u64,
+    /// Raw code block contents from this message (for clipboard copy)
+    pub(super) code_blocks: Vec<String>,
 }
 
 /// Line cache for efficient rendering
@@ -62,7 +64,8 @@ impl ChatView {
     ) -> CachedMessageLines {
         let mut lines = Vec::new();
         let mut joiner_before = Vec::new();
-        self.format_message_with_joiners(msg, width, &mut lines, &mut joiner_before);
+        let code_blocks =
+            self.format_message_with_joiners(msg, width, &mut lines, &mut joiner_before);
         if add_spacing {
             lines.push(Line::from(""));
             joiner_before.push(None);
@@ -71,6 +74,7 @@ impl ChatView {
             lines,
             joiner_before,
             content_hash: Self::compute_message_hash(msg),
+            code_blocks,
         }
     }
 
@@ -170,18 +174,24 @@ impl ChatView {
         self.flat_cache.reserve(self.line_cache.total_line_count);
         self.joiner_before.clear();
         self.joiner_before.reserve(self.line_cache.total_line_count);
-        for cached in self.line_cache.entries.iter().flatten() {
-            for (line, joiner) in cached.lines.iter().zip(cached.joiner_before.iter()) {
-                // Skip consecutive blank lines to avoid excessive spacing
-                let is_blank = is_blank_line(line);
-                let last_is_blank = self.flat_cache.last().map(is_blank_line).unwrap_or(false);
+        self.flat_cache_entry_spans.clear();
+        for entry_opt in self.line_cache.entries.iter() {
+            let entry_start = self.flat_cache.len();
+            if let Some(cached) = entry_opt {
+                for (line, joiner) in cached.lines.iter().zip(cached.joiner_before.iter()) {
+                    // Skip consecutive blank lines to avoid excessive spacing
+                    let is_blank = is_blank_line(line);
+                    let last_is_blank = self.flat_cache.last().map(is_blank_line).unwrap_or(false);
 
-                if is_blank && last_is_blank {
-                    continue;
+                    if is_blank && last_is_blank {
+                        continue;
+                    }
+                    self.flat_cache.push(line.clone());
+                    self.joiner_before.push(joiner.clone());
                 }
-                self.flat_cache.push(line.clone());
-                self.joiner_before.push(joiner.clone());
             }
+            self.flat_cache_entry_spans
+                .push((entry_start, self.flat_cache.len()));
         }
         self.flat_cache_width = self.cache_width;
         self.flat_cache_dirty = false;

--- a/src/ui/components/inline_prompt.rs
+++ b/src/ui/components/inline_prompt.rs
@@ -1238,21 +1238,54 @@ impl<'a> InlinePrompt<'a> {
         // Render prompt and input
         let prompt_style = Style::default().fg(accent_primary());
         let input_style = Style::default().fg(text_primary());
+        let cursor_style = Style::default().add_modifier(Modifier::REVERSED);
 
-        // Draw prompt
+        // Draw prompt prefix on first line
         buf[(area.x, area.y)].set_char('>').set_style(prompt_style);
         buf[(area.x + 1, area.y)]
             .set_char(' ')
             .set_style(prompt_style);
 
-        // Draw input text with cursor
+        // Build spans with cursor highlighted so Paragraph wrapping positions it correctly
+        let input = &self.state.text_input.input;
+        let cursor_pos = self.state.text_input.cursor;
+        let spans = if input.is_empty() {
+            vec![Span::styled(" ", cursor_style)]
+        } else if cursor_pos >= input.len() {
+            vec![
+                Span::styled(input.clone(), input_style),
+                Span::styled(" ", cursor_style),
+            ]
+        } else {
+            let (before, after) = input.split_at(cursor_pos);
+            let (cursor_char, rest) = after.split_at(1);
+            vec![
+                Span::styled(before.to_string(), input_style),
+                Span::styled(cursor_char.to_string(), cursor_style),
+                Span::styled(rest.to_string(), input_style),
+            ]
+        };
+
+        // Draw input text with wrapping in the area to the right of the prompt prefix
         let input_area = Rect {
             x: area.x + 2,
             y: area.y,
             width: area.width.saturating_sub(2),
-            height: 1,
+            height: area.height,
         };
-        self.state.text_input.render(input_area, buf, input_style);
+        Paragraph::new(Line::from(spans))
+            .wrap(Wrap { trim: false })
+            .render(input_area, buf);
+    }
+
+    /// Compute how many lines the text input will occupy given the available width.
+    fn input_height(&self, available_width: u16) -> u16 {
+        if available_width == 0 {
+            return 1;
+        }
+        // +1 for the cursor space appended after the text
+        let text_len = (self.state.text_input.input.len() + 1) as u16;
+        ((text_len + available_width - 1) / available_width).max(1)
     }
 }
 
@@ -1376,17 +1409,19 @@ impl Widget for InlinePrompt<'_> {
                     y += 2;
 
                     if self.state.input_mode {
-                        // Render text input
+                        // Render text input — height grows with content to enable line wrapping
+                        let input_w = area.width.saturating_sub(2); // 2 for "> "
+                        let input_h = self.input_height(input_w);
                         self.render_input(
                             Rect {
                                 x: area.x,
                                 y,
                                 width: area.width,
-                                height: 1,
+                                height: input_h,
                             },
                             buf,
                         );
-                        y += 2;
+                        y += input_h + 1;
 
                         // Input mode instructions
                         InstructionBar::new(vec![("Enter", "submit"), ("Esc", "go back")]).render(
@@ -1563,17 +1598,19 @@ impl Widget for InlinePrompt<'_> {
                         );
                     y += 2;
 
-                    // Text input
+                    // Text input — height grows with content to enable line wrapping
+                    let input_w = area.width.saturating_sub(3); // 1 indent + 2 for "> "
+                    let input_h = self.input_height(input_w);
                     self.render_input(
                         Rect {
                             x: area.x + 1,
                             y,
                             width: area.width.saturating_sub(1),
-                            height: 1,
+                            height: input_h,
                         },
                         buf,
                     );
-                    y += 2;
+                    y += input_h + 1;
 
                     // File path
                     let path_style = Style::default().fg(text_faint());

--- a/src/ui/components/markdown.rs
+++ b/src/ui/components/markdown.rs
@@ -12,17 +12,20 @@ use super::theme::text_primary;
 pub struct MarkdownRenderer {
     /// Base style for text
     base_style: Style,
+    /// Raw code block contents captured during render (one entry per code block)
+    pub code_blocks: Vec<String>,
 }
 
 impl MarkdownRenderer {
     pub fn new() -> Self {
         Self {
             base_style: Style::default().fg(text_primary()),
+            code_blocks: Vec::new(),
         }
     }
 
     /// Render markdown string to ratatui Text
-    pub fn render(&self, markdown: &str) -> Text<'static> {
+    pub fn render(&mut self, markdown: &str) -> Text<'static> {
         let mut options = Options::empty();
         options.insert(Options::ENABLE_TABLES);
         options.insert(Options::ENABLE_STRIKETHROUGH);
@@ -157,6 +160,8 @@ impl MarkdownRenderer {
                     }
                     TagEnd::CodeBlock => {
                         in_code_block = false;
+                        // Save raw content before rendering so callers can copy it
+                        self.code_blocks.push(code_block_content.clone());
                         let fence_label = code_block_language
                             .as_deref()
                             .filter(|language| !language.trim().is_empty())
@@ -273,7 +278,7 @@ impl MarkdownRenderer {
     }
 
     /// Render markdown and wrap output to the requested display width.
-    pub fn render_wrapped(&self, markdown: &str, width: usize) -> Vec<Line<'static>> {
+    pub fn render_wrapped(&mut self, markdown: &str, width: usize) -> Vec<Line<'static>> {
         if width == 0 {
             return Vec::new();
         }
@@ -510,7 +515,7 @@ mod tests {
 | Alice | 30 |
 | Bob | 25 |
 "#;
-        let renderer = MarkdownRenderer::new();
+        let mut renderer = MarkdownRenderer::new();
         let text = renderer.render(md);
         assert!(!text.lines.is_empty());
     }
@@ -524,7 +529,7 @@ fn main() {
 }
 ```
 "#;
-        let renderer = MarkdownRenderer::new();
+        let mut renderer = MarkdownRenderer::new();
         let text = renderer.render(md);
         assert!(!text.lines.is_empty());
     }
@@ -532,7 +537,7 @@ fn main() {
     #[test]
     fn test_render_wrapped_splits_long_line() {
         let md = "This is a long markdown paragraph that should wrap.";
-        let renderer = MarkdownRenderer::new();
+        let mut renderer = MarkdownRenderer::new();
         let wrapped = renderer.render_wrapped(md, 12);
 
         assert!(wrapped.len() > 1);
@@ -541,7 +546,7 @@ fn main() {
     #[test]
     fn test_render_wrapped_preserves_inline_code_text() {
         let md = "Use `cargo check --all` in this project.";
-        let renderer = MarkdownRenderer::new();
+        let mut renderer = MarkdownRenderer::new();
         let wrapped = renderer.render_wrapped(md, 10);
 
         let text: String = wrapped

--- a/src/ui/file_viewer.rs
+++ b/src/ui/file_viewer.rs
@@ -200,7 +200,7 @@ impl FileViewerSession {
             return;
         }
 
-        let renderer = MarkdownRenderer::new();
+        let mut renderer = MarkdownRenderer::new();
         self.rendered_lines = renderer.render_wrapped(&self.content, content_width);
         self.rendered_total_lines = self.rendered_lines.len();
         self.last_render_width = Some(content_width);

--- a/src/ui/terminal_guard.rs
+++ b/src/ui/terminal_guard.rs
@@ -4,7 +4,7 @@
 //! when the application exits, whether normally, via early return, or panic.
 
 use crossterm::{
-    event::{DisableMouseCapture, PopKeyboardEnhancementFlags},
+    event::{DisableBracketedPaste, DisableMouseCapture, PopKeyboardEnhancementFlags},
     execute,
     terminal::{disable_raw_mode, LeaveAlternateScreen},
 };
@@ -66,7 +66,7 @@ impl TerminalGuard {
             }
         }
         disable_raw_mode()?;
-        execute!(stdout, LeaveAlternateScreen, DisableMouseCapture)?;
+        execute!(stdout, LeaveAlternateScreen, DisableMouseCapture, DisableBracketedPaste)?;
         stdout.flush()?;
         Ok(())
     }
@@ -103,7 +103,7 @@ pub fn install_panic_hook() {
         if let Err(e) = disable_raw_mode() {
             tracing::debug!(error = %e, "Failed to disable raw mode in panic hook");
         }
-        if let Err(e) = execute!(stdout, LeaveAlternateScreen, DisableMouseCapture) {
+        if let Err(e) = execute!(stdout, LeaveAlternateScreen, DisableMouseCapture, DisableBracketedPaste) {
             tracing::debug!(error = %e, "Failed to restore terminal screen in panic hook");
         }
         if let Err(e) = stdout.flush() {

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -5,6 +5,7 @@ pub mod paths;
 pub mod project_folders;
 pub mod title_generator;
 pub mod tools;
+pub mod workspace_setup;
 
 pub use names::{generate_branch_name, generate_workspace_name, get_git_username};
 pub use paths::{

--- a/src/util/workspace_setup.rs
+++ b/src/util/workspace_setup.rs
@@ -1,0 +1,52 @@
+//! Workspace setup script support.
+
+use std::path::Path;
+
+/// Run `workspace_setup.sh` from the base repo path inside the new workspace directory.
+///
+/// The script is looked up in the repository root (not the workspace). If it doesn't
+/// exist the function is a no-op. Failures are logged as warnings but do not prevent
+/// workspace creation from succeeding.
+pub fn run_workspace_setup_script(repo_path: &Path, workspace_path: &Path) {
+    let script = repo_path.join("workspace_setup.sh");
+    if !script.exists() {
+        return;
+    }
+
+    tracing::info!(
+        script = %script.display(),
+        workspace = %workspace_path.display(),
+        "Running workspace setup script"
+    );
+
+    match std::process::Command::new(&script)
+        .current_dir(workspace_path)
+        .env("WORKSPACE_PATH", workspace_path)
+        .output()
+    {
+        Ok(output) => {
+            if output.status.success() {
+                tracing::info!(
+                    workspace = %workspace_path.display(),
+                    "Workspace setup script completed successfully"
+                );
+            } else {
+                tracing::warn!(
+                    workspace = %workspace_path.display(),
+                    stderr = %String::from_utf8_lossy(&output.stderr),
+                    stdout = %String::from_utf8_lossy(&output.stdout),
+                    status = %output.status,
+                    "Workspace setup script failed"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                script = %script.display(),
+                workspace = %workspace_path.display(),
+                "Failed to run workspace setup script"
+            );
+        }
+    }
+}

--- a/src/web/handlers/sessions.rs
+++ b/src/web/handlers/sessions.rs
@@ -22,7 +22,7 @@ use crate::ui::app_prompt;
 use crate::ui::components::{ChatMessage, MessageRole};
 use crate::util::names::{generate_branch_name, generate_workspace_name, get_git_username};
 use crate::web::error::WebError;
-use crate::web::handlers::workspaces::WorkspaceResponse;
+use crate::web::handlers::workspaces::{run_workspace_setup_script, WorkspaceResponse};
 use crate::web::state::WebAppState;
 
 /// Response for a single session.
@@ -650,6 +650,8 @@ pub async fn fork_session(
             e
         )));
     }
+
+    run_workspace_setup_script(&base_repo_path, &new_workspace.path);
 
     let forked_session = SessionService::create_forked_session(
         &core,

--- a/src/web/handlers/sessions.rs
+++ b/src/web/handlers/sessions.rs
@@ -22,7 +22,8 @@ use crate::ui::app_prompt;
 use crate::ui::components::{ChatMessage, MessageRole};
 use crate::util::names::{generate_branch_name, generate_workspace_name, get_git_username};
 use crate::web::error::WebError;
-use crate::web::handlers::workspaces::{run_workspace_setup_script, WorkspaceResponse};
+use crate::util::workspace_setup::run_workspace_setup_script;
+use crate::web::handlers::workspaces::WorkspaceResponse;
 use crate::web::state::WebAppState;
 
 /// Response for a single session.

--- a/src/web/handlers/workspaces.rs
+++ b/src/web/handlers/workspaces.rs
@@ -570,6 +570,8 @@ pub async fn auto_create_workspace(
         WebError::Internal(format!("Failed to save workspace: {}", e))
     })?;
 
+    run_workspace_setup_script(&repo_path, &workspace.path);
+
     let response = WorkspaceResponse::from(workspace.clone());
     state
         .status_manager()
@@ -825,4 +827,56 @@ pub async fn read_workspace_file(
         media_type,
         exists: true,
     }))
+}
+
+/// Run `workspace_setup.sh` from the base repo path inside the new workspace directory.
+///
+/// The script is looked up in the repository root (not the workspace). If it doesn't
+/// exist the function is a no-op. Failures are logged as warnings but do not prevent
+/// workspace creation from succeeding.
+pub(super) fn run_workspace_setup_script(
+    repo_path: &std::path::Path,
+    workspace_path: &std::path::Path,
+) {
+    let script = repo_path.join("workspace_setup.sh");
+    if !script.exists() {
+        return;
+    }
+
+    tracing::info!(
+        script = %script.display(),
+        workspace = %workspace_path.display(),
+        "Running workspace setup script"
+    );
+
+    match std::process::Command::new(&script)
+        .current_dir(workspace_path)
+        .env("WORKSPACE_PATH", workspace_path)
+        .output()
+    {
+        Ok(output) => {
+            if output.status.success() {
+                tracing::info!(
+                    workspace = %workspace_path.display(),
+                    "Workspace setup script completed successfully"
+                );
+            } else {
+                tracing::warn!(
+                    workspace = %workspace_path.display(),
+                    stderr = %String::from_utf8_lossy(&output.stderr),
+                    stdout = %String::from_utf8_lossy(&output.stdout),
+                    status = %output.status,
+                    "Workspace setup script failed"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                script = %script.display(),
+                workspace = %workspace_path.display(),
+                "Failed to run workspace setup script"
+            );
+        }
+    }
 }

--- a/src/web/handlers/workspaces.rs
+++ b/src/web/handlers/workspaces.rs
@@ -14,6 +14,7 @@ use crate::core::services::{ServiceError, SessionService};
 use crate::data::Workspace;
 use crate::git::PrManager;
 use crate::util::names::{generate_branch_name, generate_workspace_name, get_git_username};
+use crate::util::workspace_setup::run_workspace_setup_script;
 use crate::web::error::WebError;
 use crate::web::handlers::sessions::SessionResponse;
 use crate::web::state::WebAppState;
@@ -829,54 +830,3 @@ pub async fn read_workspace_file(
     }))
 }
 
-/// Run `workspace_setup.sh` from the base repo path inside the new workspace directory.
-///
-/// The script is looked up in the repository root (not the workspace). If it doesn't
-/// exist the function is a no-op. Failures are logged as warnings but do not prevent
-/// workspace creation from succeeding.
-pub(super) fn run_workspace_setup_script(
-    repo_path: &std::path::Path,
-    workspace_path: &std::path::Path,
-) {
-    let script = repo_path.join("workspace_setup.sh");
-    if !script.exists() {
-        return;
-    }
-
-    tracing::info!(
-        script = %script.display(),
-        workspace = %workspace_path.display(),
-        "Running workspace setup script"
-    );
-
-    match std::process::Command::new(&script)
-        .current_dir(workspace_path)
-        .env("WORKSPACE_PATH", workspace_path)
-        .output()
-    {
-        Ok(output) => {
-            if output.status.success() {
-                tracing::info!(
-                    workspace = %workspace_path.display(),
-                    "Workspace setup script completed successfully"
-                );
-            } else {
-                tracing::warn!(
-                    workspace = %workspace_path.display(),
-                    stderr = %String::from_utf8_lossy(&output.stderr),
-                    stdout = %String::from_utf8_lossy(&output.stdout),
-                    status = %output.status,
-                    "Workspace setup script failed"
-                );
-            }
-        }
-        Err(e) => {
-            tracing::warn!(
-                error = %e,
-                script = %script.display(),
-                workspace = %workspace_path.display(),
-                "Failed to run workspace setup script"
-            );
-        }
-    }
-}

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -147,6 +147,17 @@ export function ChatInput({
     fileInputRef.current?.click();
   };
 
+  const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!onAttachImages) return;
+    const files = Array.from(e.clipboardData.files).filter((f) =>
+      f.type.startsWith('image/')
+    );
+    if (files.length > 0) {
+      e.preventDefault();
+      onAttachImages(files);
+    }
+  };
+
   const handleFilesSelected = (files: FileList | null) => {
     if (!files || !onAttachImages) return;
     const nextFiles = Array.from(files);
@@ -239,6 +250,7 @@ export function ChatInput({
             value={value}
             onChange={(e) => onChange(e.target.value)}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             data-chat-input="true"
             placeholder={placeholder}
             disabled={effectiveInputDisabled}


### PR DESCRIPTION
## Summary

- The bare `y` binding for `CopyCodeBlock` was scoped to `KeyContext::Scrolling`, which is only active in `InputMode::Scrolling` — a mode that is never entered, making the hotkey unreachable
- Adds `M-y` (Option+Y) to the global keybinding context so it works from any mode, including the chat input
- The `y` binding in the Scrolling context is retained as a fallback

## Test plan

- [ ] Press `Option+Y` while in the chat input — nearest visible code block should be copied to clipboard with a footer confirmation
- [ ] Confirm `y` no longer accidentally types into the input when trying to copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keybindings (M-y, y) to copy code blocks from chat messages
  * Implemented OSC 52 clipboard support for remote/SSH terminal sessions
  * Added automatic workspace setup script execution on workspace creation
  * Enabled direct image pasting into chat input

* **Improvements**
  * Enhanced text input rendering with dynamic height and improved text wrapping
  * Fixed tab navigation to properly cycle through open tabs without sidebar interference
  * Added bracketed paste mode terminal support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->