### PR TITLE
fix: properly add Pi provider support across model discovery and web UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /after-click-*.png
 /open-new-tab.png
 /web-ui.png
+.beans/

--- a/src/agent/claude.rs
+++ b/src/agent/claude.rs
@@ -392,6 +392,11 @@ impl AgentRunner for ClaudeCodeRunner {
                             AgentInput::PiFollowUp { .. } => {
                                 tracing::warn!("Ignored Pi follow-up sent to Claude input channel");
                             }
+                            AgentInput::PiSetFollowUpMode { .. } => {
+                                tracing::warn!(
+                                    "Ignored Pi follow-up mode update sent to Claude input channel"
+                                );
+                            }
                             AgentInput::OpencodeQuestion { .. } => {
                                 tracing::warn!(
                                     "Ignored OpenCode question response sent to Claude input channel"

--- a/src/agent/claude.rs
+++ b/src/agent/claude.rs
@@ -384,6 +384,11 @@ impl AgentRunner for ClaudeCodeRunner {
                             AgentInput::CodexPrompt { .. } => {
                                 tracing::warn!("Ignored Codex prompt sent to Claude input channel");
                             }
+                            AgentInput::PiSetThinkingLevel { .. } => {
+                                tracing::warn!(
+                                    "Ignored Pi thinking level update sent to Claude input channel"
+                                );
+                            }
                             AgentInput::OpencodeQuestion { .. } => {
                                 tracing::warn!(
                                     "Ignored OpenCode question response sent to Claude input channel"

--- a/src/agent/claude.rs
+++ b/src/agent/claude.rs
@@ -389,6 +389,9 @@ impl AgentRunner for ClaudeCodeRunner {
                                     "Ignored Pi thinking level update sent to Claude input channel"
                                 );
                             }
+                            AgentInput::PiFollowUp { .. } => {
+                                tracing::warn!("Ignored Pi follow-up sent to Claude input channel");
+                            }
                             AgentInput::OpencodeQuestion { .. } => {
                                 tracing::warn!(
                                     "Ignored OpenCode question response sent to Claude input channel"

--- a/src/agent/codex.rs
+++ b/src/agent/codex.rs
@@ -1363,6 +1363,11 @@ impl AgentRunner for CodexCliRunner {
                     AgentInput::PiFollowUp { .. } => {
                         tracing::warn!("Ignored Pi follow-up sent to Codex input channel");
                     }
+                    AgentInput::PiSetFollowUpMode { .. } => {
+                        tracing::warn!(
+                            "Ignored Pi follow-up mode update sent to Codex input channel"
+                        );
+                    }
                     AgentInput::OpencodeQuestion { .. } => {
                         tracing::warn!(
                             "Ignored OpenCode question response sent to Codex input channel"

--- a/src/agent/codex.rs
+++ b/src/agent/codex.rs
@@ -1360,6 +1360,9 @@ impl AgentRunner for CodexCliRunner {
                             "Ignored Pi thinking level update sent to Codex input channel"
                         );
                     }
+                    AgentInput::PiFollowUp { .. } => {
+                        tracing::warn!("Ignored Pi follow-up sent to Codex input channel");
+                    }
                     AgentInput::OpencodeQuestion { .. } => {
                         tracing::warn!(
                             "Ignored OpenCode question response sent to Codex input channel"

--- a/src/agent/codex.rs
+++ b/src/agent/codex.rs
@@ -1355,6 +1355,11 @@ impl AgentRunner for CodexCliRunner {
                     AgentInput::ClaudeJsonl(_) => {
                         tracing::warn!("Ignored Claude JSONL sent to Codex input channel");
                     }
+                    AgentInput::PiSetThinkingLevel { .. } => {
+                        tracing::warn!(
+                            "Ignored Pi thinking level update sent to Codex input channel"
+                        );
+                    }
                     AgentInput::OpencodeQuestion { .. } => {
                         tracing::warn!(
                             "Ignored OpenCode question response sent to Codex input channel"

--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -15,6 +15,7 @@ use serde::Deserialize;
 use serde_json::Value;
 
 use super::display::MessageDisplay;
+use crate::agent::ReasoningEffort;
 use crate::ui::components::{ChatMessage, MessageRole, TurnSummary};
 
 /// Info extracted from a function_call entry for later lookup
@@ -2126,6 +2127,64 @@ fn pi_message_to_chat_message(message: &Value) -> Option<ChatMessage> {
     }
 }
 
+fn pi_reasoning_effort_from_level(level: &str) -> Option<ReasoningEffort> {
+    match level {
+        "minimal" => Some(ReasoningEffort::Minimal),
+        "low" => Some(ReasoningEffort::Low),
+        "medium" => Some(ReasoningEffort::Medium),
+        "high" => Some(ReasoningEffort::High),
+        "xhigh" => Some(ReasoningEffort::XHigh),
+        _ => None,
+    }
+}
+
+pub fn load_pi_reasoning_effort(
+    session_ref: &str,
+) -> Result<Option<ReasoningEffort>, HistoryError> {
+    let session_file = find_pi_session_file(session_ref)?;
+    let file = File::open(&session_file)?;
+    let reader = BufReader::new(file);
+
+    let mut all_entries: HashMap<String, Value> = HashMap::new();
+    let mut last_entry_id: Option<String> = None;
+
+    for (line_number, line) in reader.lines().enumerate() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(&line)
+            .map_err(|err| HistoryError::ParseError(format!("line {}: {err}", line_number + 1)))?;
+        if let Some(id) = value.get("id").and_then(Value::as_str) {
+            last_entry_id = Some(id.to_string());
+            all_entries.insert(id.to_string(), value);
+        }
+    }
+
+    let Some(mut current_id) = last_entry_id else {
+        return Ok(None);
+    };
+
+    while let Some(entry) = all_entries.get(&current_id) {
+        if entry.get("type").and_then(Value::as_str) == Some("thinking_level_change") {
+            let effort = entry
+                .get("thinkingLevel")
+                .and_then(Value::as_str)
+                .and_then(pi_reasoning_effort_from_level);
+            return Ok(effort);
+        }
+        let Some(parent) = entry.get("parentId").and_then(Value::as_str) else {
+            break;
+        };
+        if !all_entries.contains_key(parent) {
+            break;
+        }
+        current_id = parent.to_string();
+    }
+
+    Ok(None)
+}
+
 /// Load Pi history from a session file path or session id.
 pub fn load_pi_history_with_debug(
     session_ref: &str,
@@ -3014,6 +3073,62 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].role, MessageRole::Error);
         assert!(messages[0].content.contains("Model missing"));
+    }
+
+    #[test]
+    fn test_load_pi_reasoning_effort_uses_latest_branch_change() {
+        let temp = TempDir::new().unwrap();
+        let session_file = temp.path().join("pi-session.jsonl");
+        fs::write(
+            &session_file,
+            [
+                serde_json::json!({
+                    "type": "session",
+                    "version": 3,
+                    "id": "pi-session-id",
+                    "timestamp": "2026-04-02T10:00:00.000Z",
+                    "cwd": "/tmp/pi-demo"
+                })
+                .to_string(),
+                serde_json::json!({
+                    "type": "message",
+                    "id": "a1",
+                    "parentId": null,
+                    "timestamp": "2026-04-02T10:00:01.000Z",
+                    "message": {"role": "user", "content": [{"type": "text", "text": "Hello"}]}
+                })
+                .to_string(),
+                serde_json::json!({
+                    "type": "thinking_level_change",
+                    "id": "a2",
+                    "parentId": "a1",
+                    "timestamp": "2026-04-02T10:00:02.000Z",
+                    "thinkingLevel": "low"
+                })
+                .to_string(),
+                serde_json::json!({
+                    "type": "message",
+                    "id": "b2",
+                    "parentId": "a1",
+                    "timestamp": "2026-04-02T10:00:03.000Z",
+                    "message": {"role": "assistant", "content": [{"type": "text", "text": "New branch"}]}
+                })
+                .to_string(),
+                serde_json::json!({
+                    "type": "thinking_level_change",
+                    "id": "b3",
+                    "parentId": "b2",
+                    "timestamp": "2026-04-02T10:00:04.000Z",
+                    "thinkingLevel": "high"
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let effort = load_pi_reasoning_effort(session_file.to_str().unwrap()).unwrap();
+        assert_eq!(effort, Some(ReasoningEffort::High));
     }
 
     #[test]

--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -2138,15 +2138,19 @@ fn pi_reasoning_effort_from_level(level: &str) -> Option<ReasoningEffort> {
     }
 }
 
-pub fn load_pi_reasoning_effort(
-    session_ref: &str,
-) -> Result<Option<ReasoningEffort>, HistoryError> {
-    let session_file = find_pi_session_file(session_ref)?;
-    let file = File::open(&session_file)?;
+struct PiSessionEntries {
+    all_entries: HashMap<String, Value>,
+    last_entry_id: Option<String>,
+    message_entry_ids: Vec<String>,
+}
+
+fn parse_pi_session_entries(session_file: &Path) -> Result<PiSessionEntries, HistoryError> {
+    let file = File::open(session_file)?;
     let reader = BufReader::new(file);
 
     let mut all_entries: HashMap<String, Value> = HashMap::new();
     let mut last_entry_id: Option<String> = None;
+    let mut message_entry_ids = Vec::new();
 
     for (line_number, line) in reader.lines().enumerate() {
         let line = line?;
@@ -2155,17 +2159,38 @@ pub fn load_pi_reasoning_effort(
         }
         let value: Value = serde_json::from_str(&line)
             .map_err(|err| HistoryError::ParseError(format!("line {}: {err}", line_number + 1)))?;
+        let entry_type = value
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
         if let Some(id) = value.get("id").and_then(Value::as_str) {
             last_entry_id = Some(id.to_string());
+            if entry_type == "message" {
+                message_entry_ids.push(id.to_string());
+            }
             all_entries.insert(id.to_string(), value);
         }
     }
 
-    let Some(mut current_id) = last_entry_id else {
+    Ok(PiSessionEntries {
+        all_entries,
+        last_entry_id,
+        message_entry_ids,
+    })
+}
+
+pub fn load_pi_reasoning_effort(
+    session_ref: &str,
+) -> Result<Option<ReasoningEffort>, HistoryError> {
+    let session_file = find_pi_session_file(session_ref)?;
+    let parsed = parse_pi_session_entries(&session_file)?;
+
+    let Some(mut current_id) = parsed.last_entry_id else {
         return Ok(None);
     };
 
-    while let Some(entry) = all_entries.get(&current_id) {
+    while let Some(entry) = parsed.all_entries.get(&current_id) {
         if entry.get("type").and_then(Value::as_str) == Some("thinking_level_change") {
             let effort = entry
                 .get("thinkingLevel")
@@ -2176,7 +2201,7 @@ pub fn load_pi_reasoning_effort(
         let Some(parent) = entry.get("parentId").and_then(Value::as_str) else {
             break;
         };
-        if !all_entries.contains_key(parent) {
+        if !parsed.all_entries.contains_key(parent) {
             break;
         }
         current_id = parent.to_string();
@@ -2190,12 +2215,11 @@ pub fn load_pi_history_with_debug(
     session_ref: &str,
 ) -> Result<(Vec<ChatMessage>, Vec<HistoryDebugEntry>, PathBuf), HistoryError> {
     let session_file = find_pi_session_file(session_ref)?;
+    let parsed = parse_pi_session_entries(&session_file)?;
+
     let file = File::open(&session_file)?;
     let reader = BufReader::new(file);
-
     let mut debug_entries = Vec::new();
-    let mut all_entries: HashMap<String, Value> = HashMap::new();
-    let mut message_entry_ids = Vec::new();
 
     for (line_number, line) in reader.lines().enumerate() {
         let line = line?;
@@ -2216,15 +2240,8 @@ pub fn load_pi_history_with_debug(
                 .and_then(|message| message.get("role"))
                 .and_then(Value::as_str)
                 .unwrap_or("unknown");
-            if let Some(id) = value.get("id").and_then(Value::as_str) {
-                all_entries.insert(id.to_string(), value.clone());
-                message_entry_ids.push(id.to_string());
-            }
             ("INCLUDE".to_string(), format!("role={role}"))
         } else {
-            if let Some(id) = value.get("id").and_then(Value::as_str) {
-                all_entries.insert(id.to_string(), value.clone());
-            }
             ("SKIP".to_string(), format!("type={entry_type}"))
         };
 
@@ -2237,19 +2254,19 @@ pub fn load_pi_history_with_debug(
         });
     }
 
-    let Some(mut current_id) = message_entry_ids.last().cloned() else {
+    let Some(mut current_id) = parsed.message_entry_ids.last().cloned() else {
         return Ok((Vec::new(), debug_entries, session_file));
     };
 
     let mut branch_ids = Vec::new();
-    while let Some(entry) = all_entries.get(&current_id) {
+    while let Some(entry) = parsed.all_entries.get(&current_id) {
         branch_ids.push(current_id.clone());
         let parent = entry
             .get("parentId")
             .and_then(Value::as_str)
             .map(str::to_string);
         let Some(parent) = parent else { break };
-        if !all_entries.contains_key(&parent) {
+        if !parsed.all_entries.contains_key(&parent) {
             break;
         }
         current_id = parent;
@@ -2258,7 +2275,7 @@ pub fn load_pi_history_with_debug(
 
     let mut messages = Vec::new();
     for entry_id in branch_ids {
-        let Some(entry) = all_entries.get(&entry_id) else {
+        let Some(entry) = parsed.all_entries.get(&entry_id) else {
             continue;
         };
         if entry.get("type").and_then(Value::as_str) != Some("message") {

--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -2129,6 +2129,7 @@ fn pi_message_to_chat_message(message: &Value) -> Option<ChatMessage> {
 
 fn pi_reasoning_effort_from_level(level: &str) -> Option<ReasoningEffort> {
     match level {
+        "off" => Some(ReasoningEffort::Off),
         "minimal" => Some(ReasoningEffort::Minimal),
         "low" => Some(ReasoningEffort::Low),
         "medium" => Some(ReasoningEffort::Medium),
@@ -3146,6 +3147,46 @@ mod tests {
 
         let effort = load_pi_reasoning_effort(session_file.to_str().unwrap()).unwrap();
         assert_eq!(effort, Some(ReasoningEffort::High));
+    }
+
+    #[test]
+    fn test_load_pi_reasoning_effort_restores_off() {
+        let temp = TempDir::new().unwrap();
+        let session_file = temp.path().join("pi-session.jsonl");
+        fs::write(
+            &session_file,
+            [
+                serde_json::json!({
+                    "type": "session",
+                    "version": 3,
+                    "id": "pi-session-id",
+                    "timestamp": "2026-04-02T10:00:00.000Z",
+                    "cwd": "/tmp/pi-demo"
+                })
+                .to_string(),
+                serde_json::json!({
+                    "type": "message",
+                    "id": "a1",
+                    "parentId": null,
+                    "timestamp": "2026-04-02T10:00:01.000Z",
+                    "message": {"role": "user", "content": [{"type": "text", "text": "Hello"}]}
+                })
+                .to_string(),
+                serde_json::json!({
+                    "type": "thinking_level_change",
+                    "id": "a2",
+                    "parentId": "a1",
+                    "timestamp": "2026-04-02T10:00:02.000Z",
+                    "thinkingLevel": "off"
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let effort = load_pi_reasoning_effort(session_file.to_str().unwrap()).unwrap();
+        assert_eq!(effort, Some(ReasoningEffort::Off));
     }
 
     #[test]

--- a/src/agent/history.rs
+++ b/src/agent/history.rs
@@ -1987,6 +1987,232 @@ pub fn load_opencode_history_for_dir_with_debug(
     Ok((session_id, messages, debug_entries, session_file))
 }
 
+fn pi_sessions_root() -> Result<PathBuf, HistoryError> {
+    let home = dirs::home_dir().ok_or(HistoryError::HomeNotFound)?;
+    Ok(home.join(".pi").join("agent").join("sessions"))
+}
+
+fn find_pi_session_file(session_ref: &str) -> Result<PathBuf, HistoryError> {
+    let path = PathBuf::from(session_ref);
+    if path.exists() {
+        return Ok(path);
+    }
+
+    let root = pi_sessions_root()?;
+    if !root.exists() {
+        return Err(HistoryError::SessionNotFound(session_ref.to_string()));
+    }
+
+    for dir_entry in fs::read_dir(&root)? {
+        let dir_entry = match dir_entry {
+            Ok(entry) => entry,
+            Err(_) => continue,
+        };
+        let project_dir = dir_entry.path();
+        if !project_dir.is_dir() {
+            continue;
+        }
+        for file_entry in fs::read_dir(&project_dir)? {
+            let file_entry = match file_entry {
+                Ok(entry) => entry,
+                Err(_) => continue,
+            };
+            let file_path = file_entry.path();
+            if file_path.extension().and_then(|ext| ext.to_str()) != Some("jsonl") {
+                continue;
+            }
+            if file_path.file_stem().and_then(|stem| stem.to_str()) == Some(session_ref) {
+                return Ok(file_path);
+            }
+            let file = match File::open(&file_path) {
+                Ok(file) => file,
+                Err(_) => continue,
+            };
+            let mut reader = BufReader::new(file);
+            let mut header = String::new();
+            if reader.read_line(&mut header).is_ok()
+                && serde_json::from_str::<Value>(&header)
+                    .ok()
+                    .and_then(|value| value.get("id").and_then(Value::as_str).map(str::to_string))
+                    .as_deref()
+                    == Some(session_ref)
+            {
+                return Ok(file_path);
+            }
+        }
+    }
+
+    Err(HistoryError::SessionNotFound(session_ref.to_string()))
+}
+
+fn pi_message_text(message: &Value) -> String {
+    match message.get("content") {
+        Some(Value::String(text)) => text.clone(),
+        Some(Value::Array(blocks)) => blocks
+            .iter()
+            .filter_map(|block| {
+                let block_type = block.get("type").and_then(Value::as_str)?;
+                match block_type {
+                    "text" => block
+                        .get("text")
+                        .and_then(Value::as_str)
+                        .map(str::to_string),
+                    _ => None,
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    }
+}
+
+fn pi_message_to_chat_message(message: &Value) -> Option<ChatMessage> {
+    let role = message.get("role")?.as_str()?;
+    match role {
+        "user" => {
+            let text = pi_message_text(message);
+            (!text.trim().is_empty())
+                .then(|| MessageDisplay::User { content: text }.to_chat_message())
+        }
+        "assistant" => {
+            let text = pi_message_text(message);
+            (!text.trim().is_empty()).then(|| {
+                MessageDisplay::Assistant {
+                    content: text,
+                    is_streaming: false,
+                }
+                .to_chat_message()
+            })
+        }
+        "toolResult" => {
+            let output = pi_message_text(message);
+            let tool_name = message
+                .get("toolName")
+                .and_then(Value::as_str)
+                .unwrap_or("Tool");
+            Some(
+                MessageDisplay::Tool {
+                    name: MessageDisplay::tool_display_name_owned(tool_name),
+                    args: String::new(),
+                    output,
+                    exit_code: None,
+                    file_size: None,
+                }
+                .to_chat_message(),
+            )
+        }
+        "bashExecution" => Some(
+            MessageDisplay::Tool {
+                name: "Bash".to_string(),
+                args: message
+                    .get("command")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+                output: message
+                    .get("output")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string(),
+                exit_code: message
+                    .get("exitCode")
+                    .and_then(Value::as_i64)
+                    .map(|code| code as i32),
+                file_size: None,
+            }
+            .to_chat_message(),
+        ),
+        _ => None,
+    }
+}
+
+/// Load Pi history from a session file path or session id.
+pub fn load_pi_history_with_debug(
+    session_ref: &str,
+) -> Result<(Vec<ChatMessage>, Vec<HistoryDebugEntry>, PathBuf), HistoryError> {
+    let session_file = find_pi_session_file(session_ref)?;
+    let file = File::open(&session_file)?;
+    let reader = BufReader::new(file);
+
+    let mut debug_entries = Vec::new();
+    let mut all_entries: HashMap<String, Value> = HashMap::new();
+    let mut message_entry_ids = Vec::new();
+
+    for (line_number, line) in reader.lines().enumerate() {
+        let line = line?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let value: Value = serde_json::from_str(&line)
+            .map_err(|err| HistoryError::ParseError(format!("line {}: {err}", line_number + 1)))?;
+        let entry_type = value
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown")
+            .to_string();
+
+        let (status, reason) = if entry_type == "message" {
+            let role = value
+                .get("message")
+                .and_then(|message| message.get("role"))
+                .and_then(Value::as_str)
+                .unwrap_or("unknown");
+            if let Some(id) = value.get("id").and_then(Value::as_str) {
+                all_entries.insert(id.to_string(), value.clone());
+                message_entry_ids.push(id.to_string());
+            }
+            ("INCLUDE".to_string(), format!("role={role}"))
+        } else {
+            if let Some(id) = value.get("id").and_then(Value::as_str) {
+                all_entries.insert(id.to_string(), value.clone());
+            }
+            ("SKIP".to_string(), format!("type={entry_type}"))
+        };
+
+        debug_entries.push(HistoryDebugEntry {
+            line_number,
+            entry_type,
+            status,
+            reason,
+            raw_json: value,
+        });
+    }
+
+    let Some(mut current_id) = message_entry_ids.last().cloned() else {
+        return Ok((Vec::new(), debug_entries, session_file));
+    };
+
+    let mut branch_ids = Vec::new();
+    while let Some(entry) = all_entries.get(&current_id) {
+        branch_ids.push(current_id.clone());
+        let parent = entry
+            .get("parentId")
+            .and_then(Value::as_str)
+            .map(str::to_string);
+        let Some(parent) = parent else { break };
+        if !all_entries.contains_key(&parent) {
+            break;
+        }
+        current_id = parent;
+    }
+    branch_ids.reverse();
+
+    let mut messages = Vec::new();
+    for entry_id in branch_ids {
+        let Some(entry) = all_entries.get(&entry_id) else {
+            continue;
+        };
+        if entry.get("type").and_then(Value::as_str) != Some("message") {
+            continue;
+        }
+        if let Some(message) = entry.get("message").and_then(pi_message_to_chat_message) {
+            messages.push(message);
+        }
+    }
+
+    Ok((messages, debug_entries, session_file))
+}
+
 /// Create a truncated preview of text for debug output
 fn truncate_preview(text: &str, max_len: usize) -> String {
     let preview: String = text.chars().take(max_len).collect();
@@ -2788,5 +3014,59 @@ mod tests {
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].role, MessageRole::Error);
         assert!(messages[0].content.contains("Model missing"));
+    }
+
+    #[test]
+    fn test_load_pi_history_with_debug_uses_latest_branch_messages() {
+        let temp = TempDir::new().unwrap();
+        let session_file = temp.path().join("pi-session.jsonl");
+        fs::write(
+            &session_file,
+            [
+                serde_json::json!({
+                    "type": "session",
+                    "version": 3,
+                    "id": "pi-session-id",
+                    "timestamp": "2026-04-02T10:00:00.000Z",
+                    "cwd": "/tmp/pi-demo"
+                })
+                .to_string(),
+                serde_json::json!({
+                    "type": "message",
+                    "id": "a1",
+                    "parentId": null,
+                    "timestamp": "2026-04-02T10:00:01.000Z",
+                    "message": {"role": "user", "content": [{"type": "text", "text": "Hello"}]}
+                })
+                .to_string(),
+                serde_json::json!({
+                    "type": "message",
+                    "id": "a2",
+                    "parentId": "a1",
+                    "timestamp": "2026-04-02T10:00:02.000Z",
+                    "message": {"role": "assistant", "content": [{"type": "text", "text": "Old branch"}]}
+                })
+                .to_string(),
+                serde_json::json!({
+                    "type": "message",
+                    "id": "b2",
+                    "parentId": "a1",
+                    "timestamp": "2026-04-02T10:00:03.000Z",
+                    "message": {"role": "assistant", "content": [{"type": "text", "text": "New branch"}]}
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let (messages, debug_entries, file_path) =
+            load_pi_history_with_debug(session_file.to_str().unwrap()).unwrap();
+
+        assert_eq!(file_path, session_file);
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].content, "Hello");
+        assert_eq!(messages[1].content, "New branch");
+        assert!(debug_entries.iter().any(|entry| entry.status == "INCLUDE"));
     }
 }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -21,8 +21,8 @@ pub use events::*;
 pub use gemini::GeminiCliRunner;
 pub use history::{
     load_claude_history_with_debug, load_codex_history_with_debug,
-    load_opencode_history_for_dir_with_debug, load_opencode_history_with_debug, HistoryDebugEntry,
-    HistoryError,
+    load_opencode_history_for_dir_with_debug, load_opencode_history_with_debug,
+    load_pi_history_with_debug, HistoryDebugEntry, HistoryError,
 };
 pub use mock::{MockAgentRunner, MockConfig, MockEventBuilder, MockStartError};
 pub use models::{ModelInfo, ModelRegistry};

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -29,6 +29,7 @@ pub use models::{ModelInfo, ModelRegistry};
 pub use opencode::OpencodeRunner;
 pub use pi::PiRunner;
 pub use runner::{
-    AgentHandle, AgentInput, AgentMode, AgentRunner, AgentStartConfig, AgentType, ReasoningEffort,
+    AgentHandle, AgentInput, AgentMode, AgentRunner, AgentStartConfig, AgentType, PiFollowUpMode,
+    ReasoningEffort,
 };
 pub use session::{SessionId, SessionMetadata, SessionStatus};

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -22,7 +22,7 @@ pub use gemini::GeminiCliRunner;
 pub use history::{
     load_claude_history_with_debug, load_codex_history_with_debug,
     load_opencode_history_for_dir_with_debug, load_opencode_history_with_debug,
-    load_pi_history_with_debug, HistoryDebugEntry, HistoryError,
+    load_pi_history_with_debug, load_pi_reasoning_effort, HistoryDebugEntry, HistoryError,
 };
 pub use mock::{MockAgentRunner, MockConfig, MockEventBuilder, MockStartError};
 pub use models::{ModelInfo, ModelRegistry};

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -8,6 +8,7 @@ pub mod history;
 pub mod mock;
 pub mod models;
 pub mod opencode;
+pub mod pi;
 pub mod runner;
 pub mod session;
 pub mod stream;
@@ -26,6 +27,7 @@ pub use history::{
 pub use mock::{MockAgentRunner, MockConfig, MockEventBuilder, MockStartError};
 pub use models::{ModelInfo, ModelRegistry};
 pub use opencode::OpencodeRunner;
+pub use pi::PiRunner;
 pub use runner::{
     AgentHandle, AgentInput, AgentMode, AgentRunner, AgentStartConfig, AgentType, ReasoningEffort,
 };

--- a/src/agent/models.rs
+++ b/src/agent/models.rs
@@ -5,6 +5,7 @@ use std::sync::{OnceLock, RwLock};
 use tracing::error;
 
 use crate::agent::opencode::load_opencode_models;
+use crate::agent::pi::PiRunner;
 use crate::agent::AgentType;
 
 /// Information about a model
@@ -78,11 +79,16 @@ impl ModelRegistry {
     pub const PI_CONTEXT_WINDOW: i64 = 200_000;
 
     const OPENCODE_DEFAULT_MODEL_ID: &'static str = "default";
-    const PI_DEFAULT_MODEL_ID: &'static str = "default";
+    const PI_LEGACY_DEFAULT_MODEL_ID: &'static str = "default";
 
     fn opencode_store() -> &'static RwLock<Vec<ModelInfo>> {
         static OPENCODE_MODELS: OnceLock<RwLock<Vec<ModelInfo>>> = OnceLock::new();
         OPENCODE_MODELS.get_or_init(|| RwLock::new(Vec::new()))
+    }
+
+    fn pi_store() -> &'static RwLock<Vec<ModelInfo>> {
+        static PI_MODELS: OnceLock<RwLock<Vec<ModelInfo>>> = OnceLock::new();
+        PI_MODELS.get_or_init(|| RwLock::new(Vec::new()))
     }
 
     fn opencode_default_model() -> ModelInfo {
@@ -336,16 +342,65 @@ impl ModelRegistry {
         ]
     }
 
+    pub fn set_pi_models(binary_path: Option<std::path::PathBuf>) {
+        let catalog = PiRunner::load_model_catalog(binary_path);
+        let mut models = catalog
+            .models
+            .into_iter()
+            .map(|model| {
+                let full_id = model.full_id();
+                let description = format!("Pi model from {}", model.provider);
+                let mut info = ModelInfo::new(
+                    AgentType::Pi,
+                    &full_id,
+                    &full_id,
+                    &full_id,
+                    &description,
+                    model.context_window,
+                );
+                if catalog.current_model_id.as_deref() == Some(full_id.as_str()) {
+                    info = info.as_default();
+                }
+                info
+            })
+            .collect::<Vec<_>>();
+
+        models.sort_by(|a, b| a.id.cmp(&b.id));
+        models.dedup_by(|a, b| a.id == b.id);
+        if let Some(pos) = models.iter().position(|model| model.is_default) {
+            let default = models.remove(pos);
+            models.insert(0, default);
+        }
+
+        let mut store = match Self::pi_store().write() {
+            Ok(guard) => guard,
+            Err(err) => {
+                error!(error = %err, "pi_store poisoned in set_pi_models");
+                err.into_inner()
+            }
+        };
+        *store = models;
+    }
+
+    pub fn clear_pi_models() {
+        let mut store = match Self::pi_store().write() {
+            Ok(guard) => guard,
+            Err(err) => {
+                error!(error = %err, "pi_store poisoned in clear_pi_models");
+                err.into_inner()
+            }
+        };
+        store.clear();
+    }
+
     pub fn pi_models() -> Vec<ModelInfo> {
-        vec![ModelInfo::new(
-            AgentType::Pi,
-            Self::PI_DEFAULT_MODEL_ID,
-            "Pi Default",
-            Self::PI_DEFAULT_MODEL_ID,
-            "Use Pi's current default model selection",
-            Self::PI_CONTEXT_WINDOW,
-        )
-        .as_default()]
+        match Self::pi_store().read() {
+            Ok(guard) => guard.clone(),
+            Err(err) => {
+                error!(error = %err, "pi_store poisoned in pi_models");
+                Vec::new()
+            }
+        }
     }
 
     /// Get all models grouped by agent type
@@ -376,7 +431,12 @@ impl ModelRegistry {
             AgentType::Codex => "gpt-5.4".to_string(),
             AgentType::Gemini => "gemini-2.5-pro".to_string(),
             AgentType::Opencode => Self::OPENCODE_DEFAULT_MODEL_ID.to_string(),
-            AgentType::Pi => Self::PI_DEFAULT_MODEL_ID.to_string(),
+            AgentType::Pi => Self::pi_models()
+                .into_iter()
+                .find(|model| model.is_default)
+                .or_else(|| Self::pi_models().into_iter().next())
+                .map(|model| model.id)
+                .unwrap_or_else(|| Self::PI_LEGACY_DEFAULT_MODEL_ID.to_string()),
         }
     }
 
@@ -407,6 +467,12 @@ impl ModelRegistry {
             let trimmed = id_or_alias.trim();
             if trimmed.is_empty() {
                 return None;
+            }
+            if trimmed.eq_ignore_ascii_case(Self::PI_LEGACY_DEFAULT_MODEL_ID) {
+                return Self::pi_models()
+                    .into_iter()
+                    .find(|model| model.is_default)
+                    .or_else(|| Self::pi_models().into_iter().next());
             }
             if let Some(model) = Self::pi_models()
                 .into_iter()
@@ -488,16 +554,22 @@ mod tests {
     }
 
     #[test]
-    fn test_pi_models_include_default_model() {
-        let models = ModelRegistry::pi_models();
-        let default_model = models
-            .iter()
-            .find(|model| model.is_default)
-            .expect("expected default Pi model");
-
-        assert_eq!(default_model.id, "default");
-        assert_eq!(default_model.display_name, "Pi Default");
+    fn test_pi_models_use_discovered_current_model() {
+        ModelRegistry::clear_pi_models();
         assert_eq!(ModelRegistry::default_model(AgentType::Pi), "default");
+
+        ModelRegistry::set_pi_models(None);
+        let models = ModelRegistry::pi_models();
+
+        if let Some(default_model) = models.iter().find(|model| model.is_default) {
+            assert!(default_model.id.contains('/'));
+            assert_eq!(
+                ModelRegistry::default_model(AgentType::Pi),
+                default_model.id
+            );
+        } else {
+            assert!(models.is_empty());
+        }
         assert_eq!(ModelRegistry::agent_section_title(AgentType::Pi), "Pi");
     }
 }

--- a/src/agent/models.rs
+++ b/src/agent/models.rs
@@ -74,8 +74,11 @@ impl ModelRegistry {
 
     /// Default context window for OpenCode models (approximate)
     pub const OPENCODE_CONTEXT_WINDOW: i64 = 200_000;
+    /// Default context window for Pi models (approximate)
+    pub const PI_CONTEXT_WINDOW: i64 = 200_000;
 
     const OPENCODE_DEFAULT_MODEL_ID: &'static str = "default";
+    const PI_DEFAULT_MODEL_ID: &'static str = "default";
 
     fn opencode_store() -> &'static RwLock<Vec<ModelInfo>> {
         static OPENCODE_MODELS: OnceLock<RwLock<Vec<ModelInfo>>> = OnceLock::new();
@@ -333,12 +336,25 @@ impl ModelRegistry {
         ]
     }
 
+    pub fn pi_models() -> Vec<ModelInfo> {
+        vec![ModelInfo::new(
+            AgentType::Pi,
+            Self::PI_DEFAULT_MODEL_ID,
+            "Pi Default",
+            Self::PI_DEFAULT_MODEL_ID,
+            "Use Pi's current default model selection",
+            Self::PI_CONTEXT_WINDOW,
+        )
+        .as_default()]
+    }
+
     /// Get all models grouped by agent type
     pub fn all_models() -> Vec<ModelInfo> {
         let mut models = Self::claude_models();
         models.extend(Self::codex_models());
         models.extend(Self::gemini_models());
         models.extend(Self::opencode_models());
+        models.extend(Self::pi_models());
         models
     }
 
@@ -349,6 +365,7 @@ impl ModelRegistry {
             AgentType::Codex => Self::codex_models(),
             AgentType::Gemini => Self::gemini_models(),
             AgentType::Opencode => Self::opencode_models(),
+            AgentType::Pi => Self::pi_models(),
         }
     }
 
@@ -359,6 +376,7 @@ impl ModelRegistry {
             AgentType::Codex => "gpt-5.4".to_string(),
             AgentType::Gemini => "gemini-2.5-pro".to_string(),
             AgentType::Opencode => Self::OPENCODE_DEFAULT_MODEL_ID.to_string(),
+            AgentType::Pi => Self::PI_DEFAULT_MODEL_ID.to_string(),
         }
     }
 
@@ -385,6 +403,27 @@ impl ModelRegistry {
             ));
         }
 
+        if agent_type == AgentType::Pi {
+            let trimmed = id_or_alias.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+            if let Some(model) = Self::pi_models()
+                .into_iter()
+                .find(|m| m.id == trimmed || m.alias == trimmed)
+            {
+                return Some(model);
+            }
+            return Some(ModelInfo::new(
+                AgentType::Pi,
+                trimmed,
+                trimmed,
+                trimmed,
+                "Pi model",
+                Self::PI_CONTEXT_WINDOW,
+            ));
+        }
+
         Self::models_for(agent_type)
             .into_iter()
             .find(|m| m.id == id_or_alias || m.alias == id_or_alias)
@@ -397,6 +436,7 @@ impl ModelRegistry {
             AgentType::Codex => "◎",
             AgentType::Gemini => "◆",
             AgentType::Opencode => "◍",
+            AgentType::Pi => "π",
         }
     }
 
@@ -407,6 +447,7 @@ impl ModelRegistry {
             AgentType::Codex => "Codex",
             AgentType::Gemini => "Gemini",
             AgentType::Opencode => "OpenCode",
+            AgentType::Pi => "Pi",
         }
     }
 
@@ -424,6 +465,7 @@ impl ModelRegistry {
             AgentType::Codex => Self::CODEX_CONTEXT_WINDOW,
             AgentType::Gemini => Self::GEMINI_CONTEXT_WINDOW,
             AgentType::Opencode => Self::OPENCODE_CONTEXT_WINDOW,
+            AgentType::Pi => Self::PI_CONTEXT_WINDOW,
         }
     }
 }
@@ -443,5 +485,19 @@ mod tests {
         assert_eq!(default_model.id, "gpt-5.4");
         assert_eq!(ModelRegistry::default_model(AgentType::Codex), "gpt-5.4");
         assert!(models.iter().any(|model| model.id == "gpt-5.3-codex"));
+    }
+
+    #[test]
+    fn test_pi_models_include_default_model() {
+        let models = ModelRegistry::pi_models();
+        let default_model = models
+            .iter()
+            .find(|model| model.is_default)
+            .expect("expected default Pi model");
+
+        assert_eq!(default_model.id, "default");
+        assert_eq!(default_model.display_name, "Pi Default");
+        assert_eq!(ModelRegistry::default_model(AgentType::Pi), "default");
+        assert_eq!(ModelRegistry::agent_section_title(AgentType::Pi), "Pi");
     }
 }

--- a/src/agent/opencode.rs
+++ b/src/agent/opencode.rs
@@ -2212,6 +2212,24 @@ impl AgentRunner for OpencodeRunner {
                                 return;
                             }
                         }
+                        AgentInput::PiSetFollowUpMode { .. } => {
+                            if !send_event_or_log(
+                                &event_tx,
+                                AgentEvent::Error(ErrorEvent {
+                                    message:
+                                        "OpenCode runner does not support Pi follow-up mode input."
+                                            .to_string(),
+                                    is_fatal: false,
+                                    code: None,
+                                    details: None,
+                                }),
+                                "opencode_pi_follow_up_mode_unsupported",
+                            )
+                            .await
+                            {
+                                return;
+                            }
+                        }
                         AgentInput::OpencodeQuestion {
                             request_id,
                             answers,

--- a/src/agent/opencode.rs
+++ b/src/agent/opencode.rs
@@ -2195,6 +2195,23 @@ impl AgentRunner for OpencodeRunner {
                                 return;
                             }
                         }
+                        AgentInput::PiFollowUp { .. } => {
+                            if !send_event_or_log(
+                                &event_tx,
+                                AgentEvent::Error(ErrorEvent {
+                                    message: "OpenCode runner does not support Pi follow-up input."
+                                        .to_string(),
+                                    is_fatal: false,
+                                    code: None,
+                                    details: None,
+                                }),
+                                "opencode_pi_follow_up_unsupported",
+                            )
+                            .await
+                            {
+                                return;
+                            }
+                        }
                         AgentInput::OpencodeQuestion {
                             request_id,
                             answers,

--- a/src/agent/opencode.rs
+++ b/src/agent/opencode.rs
@@ -2177,6 +2177,24 @@ impl AgentRunner for OpencodeRunner {
                                 return;
                             }
                         }
+                        AgentInput::PiSetThinkingLevel { .. } => {
+                            if !send_event_or_log(
+                                &event_tx,
+                                AgentEvent::Error(ErrorEvent {
+                                    message:
+                                        "OpenCode runner does not support Pi thinking level input."
+                                            .to_string(),
+                                    is_fatal: false,
+                                    code: None,
+                                    details: None,
+                                }),
+                                "opencode_pi_thinking_unsupported",
+                            )
+                            .await
+                            {
+                                return;
+                            }
+                        }
                         AgentInput::OpencodeQuestion {
                             request_id,
                             answers,

--- a/src/agent/pi.rs
+++ b/src/agent/pi.rs
@@ -1,8 +1,24 @@
 use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+use async_trait::async_trait;
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::{mpsc, Mutex};
 
 use crate::agent::error::AgentError;
+use crate::agent::events::{
+    AgentEvent, AssistantMessageEvent, CommandOutputEvent, ErrorEvent, ReasoningEvent,
+    SessionInitEvent, TokenUsage, ToolCompletedEvent, ToolStartedEvent, TurnCompletedEvent,
+    TurnFailedEvent,
+};
 use crate::agent::runner::{AgentHandle, AgentInput, AgentRunner, AgentStartConfig, AgentType};
-use async_trait::async_trait;
+use crate::agent::session::SessionId;
 
 pub struct PiRunner {
     binary_path: PathBuf,
@@ -28,6 +44,347 @@ impl PiRunner {
     fn find_binary() -> Option<PathBuf> {
         which::which("pi").ok()
     }
+
+    fn build_command(&self, config: &AgentStartConfig) -> Command {
+        let mut cmd = Command::new(&self.binary_path);
+        cmd.arg("--mode").arg("rpc");
+        cmd.current_dir(&config.working_dir);
+        cmd.stdin(Stdio::piped());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+
+        if let Some(session_id) = &config.resume_session {
+            cmd.arg("--session").arg(session_id.as_str());
+        }
+        if let Some(model) = &config.model {
+            cmd.arg("--model").arg(model);
+        }
+        if let Some(effort) = config.reasoning_effort {
+            cmd.arg("--thinking").arg(effort.as_str());
+        }
+        if !config.allowed_tools.is_empty() {
+            let tools = config
+                .allowed_tools
+                .iter()
+                .map(|tool| tool.trim().to_ascii_lowercase())
+                .collect::<Vec<_>>()
+                .join(",");
+            cmd.arg("--tools").arg(tools);
+        }
+        for arg in &config.additional_args {
+            cmd.arg(arg);
+        }
+
+        cmd
+    }
+
+    fn parse_event_line(line: &str) -> Result<Vec<AgentEvent>, AgentError> {
+        let value: Value = serde_json::from_str(line)?;
+        Ok(Self::parse_event_value(&value))
+    }
+
+    fn parse_event_value(value: &Value) -> Vec<AgentEvent> {
+        match value.get("type").and_then(Value::as_str) {
+            Some("response") => Self::parse_response(value),
+            Some("turn_start") => vec![AgentEvent::TurnStarted],
+            Some("turn_end") => Self::parse_turn_end(value),
+            Some("message_update") => Self::parse_message_update(value),
+            Some("message_end") => Self::parse_message_end(value),
+            Some("tool_execution_start") => Self::parse_tool_execution_start(value),
+            Some("tool_execution_update") => Self::parse_tool_execution_update(value),
+            Some("tool_execution_end") => Self::parse_tool_execution_end(value),
+            Some("extension_error") => vec![AgentEvent::Error(ErrorEvent {
+                message: value
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .unwrap_or("Pi extension error")
+                    .to_string(),
+                is_fatal: false,
+                code: Some("extension_error".to_string()),
+                details: Some(value.clone()),
+            })],
+            Some("agent_end") => Vec::new(),
+            _ => Vec::new(),
+        }
+    }
+
+    fn parse_response(value: &Value) -> Vec<AgentEvent> {
+        let success = value
+            .get("success")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let command = value.get("command").and_then(Value::as_str).unwrap_or("");
+        if !success {
+            let message = value
+                .get("error")
+                .and_then(Value::as_str)
+                .unwrap_or("Pi RPC command failed")
+                .to_string();
+            return vec![
+                AgentEvent::Error(ErrorEvent {
+                    message: message.clone(),
+                    is_fatal: true,
+                    code: Some(format!("pi_response_{command}")),
+                    details: Some(value.clone()),
+                }),
+                AgentEvent::TurnFailed(TurnFailedEvent { error: message }),
+            ];
+        }
+
+        if command != "get_state" {
+            return Vec::new();
+        }
+
+        let data = match value.get("data") {
+            Some(data) => data,
+            None => return Vec::new(),
+        };
+        let session_ref = data
+            .get("sessionFile")
+            .and_then(Value::as_str)
+            .or_else(|| data.get("sessionId").and_then(Value::as_str));
+        let Some(session_ref) = session_ref else {
+            return Vec::new();
+        };
+        let model = data
+            .get("model")
+            .and_then(|model| model.get("id"))
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned);
+
+        vec![AgentEvent::SessionInit(SessionInitEvent {
+            session_id: SessionId::from_string(session_ref),
+            model,
+        })]
+    }
+
+    fn parse_turn_end(value: &Value) -> Vec<AgentEvent> {
+        let message = value.get("message");
+        let usage = message.map(Self::extract_usage).unwrap_or_default();
+        let mut events = vec![AgentEvent::TurnCompleted(TurnCompletedEvent { usage })];
+
+        if let Some(message) = message {
+            let stop_reason = message.get("stopReason").and_then(Value::as_str);
+            if matches!(stop_reason, Some("error") | Some("aborted")) {
+                let error = message
+                    .get("errorMessage")
+                    .and_then(Value::as_str)
+                    .unwrap_or("Pi turn failed")
+                    .to_string();
+                events.push(AgentEvent::TurnFailed(TurnFailedEvent { error }));
+            }
+        }
+
+        events
+    }
+
+    fn parse_message_update(value: &Value) -> Vec<AgentEvent> {
+        let Some(delta) = value.get("assistantMessageEvent") else {
+            return Vec::new();
+        };
+        match delta.get("type").and_then(Value::as_str) {
+            Some("text_delta") => delta
+                .get("delta")
+                .and_then(Value::as_str)
+                .map(|text| {
+                    vec![AgentEvent::AssistantMessage(AssistantMessageEvent {
+                        text: text.to_string(),
+                        is_final: false,
+                    })]
+                })
+                .unwrap_or_default(),
+            Some("thinking_delta") => delta
+                .get("delta")
+                .and_then(Value::as_str)
+                .map(|text| {
+                    vec![AgentEvent::AssistantReasoning(ReasoningEvent {
+                        text: text.to_string(),
+                    })]
+                })
+                .unwrap_or_default(),
+            Some("error") => {
+                let message = delta
+                    .get("error")
+                    .and_then(Value::as_str)
+                    .or_else(|| delta.get("reason").and_then(Value::as_str))
+                    .unwrap_or("Pi message error")
+                    .to_string();
+                vec![AgentEvent::Error(ErrorEvent {
+                    message,
+                    is_fatal: true,
+                    code: Some("message_update_error".to_string()),
+                    details: Some(value.clone()),
+                })]
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn parse_message_end(value: &Value) -> Vec<AgentEvent> {
+        let Some(message) = value.get("message") else {
+            return Vec::new();
+        };
+        if message.get("role").and_then(Value::as_str) != Some("assistant") {
+            return Vec::new();
+        }
+
+        vec![AgentEvent::AssistantMessage(AssistantMessageEvent {
+            text: String::new(),
+            is_final: true,
+        })]
+    }
+
+    fn parse_tool_execution_start(value: &Value) -> Vec<AgentEvent> {
+        let tool_name = value
+            .get("toolName")
+            .and_then(Value::as_str)
+            .unwrap_or("tool")
+            .to_string();
+        let tool_id = value
+            .get("toolCallId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let arguments = value.get("args").cloned().unwrap_or(Value::Null);
+        vec![AgentEvent::ToolStarted(ToolStartedEvent {
+            tool_name,
+            tool_id,
+            arguments,
+        })]
+    }
+
+    fn parse_tool_execution_update(value: &Value) -> Vec<AgentEvent> {
+        let tool_name = value.get("toolName").and_then(Value::as_str).unwrap_or("");
+        if tool_name != "bash" {
+            return Vec::new();
+        }
+        let output = value
+            .get("partialResult")
+            .and_then(Self::extract_text_from_tool_result)
+            .unwrap_or_default();
+        let command = value
+            .get("args")
+            .and_then(|args| args.get("command"))
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        vec![AgentEvent::CommandOutput(CommandOutputEvent {
+            command,
+            output,
+            exit_code: None,
+            is_streaming: true,
+        })]
+    }
+
+    fn parse_tool_execution_end(value: &Value) -> Vec<AgentEvent> {
+        let tool_name = value
+            .get("toolName")
+            .and_then(Value::as_str)
+            .unwrap_or("tool")
+            .to_string();
+        let tool_id = value
+            .get("toolCallId")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string();
+        let is_error = value
+            .get("isError")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let result_text = value
+            .get("result")
+            .and_then(Self::extract_text_from_tool_result);
+        let mut events = vec![AgentEvent::ToolCompleted(ToolCompletedEvent {
+            tool_id,
+            success: !is_error,
+            result: if is_error { None } else { result_text.clone() },
+            error: if is_error { result_text.clone() } else { None },
+        })];
+
+        if tool_name == "bash" {
+            let command = value
+                .get("args")
+                .and_then(|args| args.get("command"))
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            events.push(AgentEvent::CommandOutput(CommandOutputEvent {
+                command,
+                output: result_text.unwrap_or_default(),
+                exit_code: None,
+                is_streaming: false,
+            }));
+        }
+
+        events
+    }
+
+    fn extract_usage(message: &Value) -> TokenUsage {
+        let Some(usage) = message.get("usage") else {
+            return TokenUsage::default();
+        };
+        TokenUsage {
+            input_tokens: usage.get("input").and_then(Value::as_i64).unwrap_or(0),
+            output_tokens: usage.get("output").and_then(Value::as_i64).unwrap_or(0),
+            cached_tokens: usage.get("cacheRead").and_then(Value::as_i64).unwrap_or(0),
+            total_tokens: usage
+                .get("totalTokens")
+                .and_then(Value::as_i64)
+                .unwrap_or_else(|| {
+                    usage.get("input").and_then(Value::as_i64).unwrap_or(0)
+                        + usage.get("output").and_then(Value::as_i64).unwrap_or(0)
+                }),
+        }
+    }
+
+    fn extract_text_from_tool_result(value: &Value) -> Option<String> {
+        let content = value.get("content")?.as_array()?;
+        let text = content
+            .iter()
+            .filter(|item| item.get("type").and_then(Value::as_str) == Some("text"))
+            .filter_map(|item| item.get("text").and_then(Value::as_str))
+            .collect::<Vec<_>>()
+            .join("");
+        Some(text)
+    }
+
+    async fn write_command_line(
+        stdin: &Arc<Mutex<tokio::process::ChildStdin>>,
+        payload: Value,
+    ) -> Result<(), AgentError> {
+        let mut guard = stdin.lock().await;
+        let line = serde_json::to_string(&payload)?;
+        guard.write_all(line.as_bytes()).await?;
+        guard.write_all(b"\n").await?;
+        guard.flush().await?;
+        Ok(())
+    }
+
+    async fn send_prompt(
+        stdin: &Arc<Mutex<tokio::process::ChildStdin>>,
+        text: String,
+        busy: &Arc<AtomicBool>,
+    ) -> Result<(), AgentError> {
+        let payload = if busy.load(Ordering::SeqCst) {
+            json!({ "type": "steer", "message": text })
+        } else {
+            json!({ "type": "prompt", "message": text })
+        };
+        Self::write_command_line(stdin, payload).await
+    }
+
+    #[cfg(unix)]
+    fn signal_pid(pid: u32, signal: i32) -> Result<(), AgentError> {
+        let result = unsafe { libc::kill(pid as i32, signal) };
+        if result == -1 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::ESRCH) {
+                return Ok(());
+            }
+            return Err(AgentError::Io(err));
+        }
+        Ok(())
+    }
 }
 
 #[async_trait]
@@ -36,28 +393,233 @@ impl AgentRunner for PiRunner {
         AgentType::Pi
     }
 
-    async fn start(&self, _config: AgentStartConfig) -> Result<AgentHandle, AgentError> {
-        Err(AgentError::NotSupported(
-            "Pi runner is not implemented yet".to_string(),
-        ))
+    async fn start(&self, config: AgentStartConfig) -> Result<AgentHandle, AgentError> {
+        let mut child = self.build_command(&config).spawn()?;
+        let pid = child.id().ok_or(AgentError::ProcessSpawnFailed)?;
+        let stdin = child.stdin.take().ok_or(AgentError::ProcessSpawnFailed)?;
+        let stdout = child.stdout.take().ok_or(AgentError::StdoutCaptureFailed)?;
+        let stderr = child.stderr.take().ok_or(AgentError::StdoutCaptureFailed)?;
+
+        let stdin = Arc::new(Mutex::new(stdin));
+        let busy = Arc::new(AtomicBool::new(false));
+        let (event_tx, event_rx) = mpsc::channel(512);
+        let (input_tx, mut input_rx) = mpsc::channel(32);
+
+        Self::write_command_line(&stdin, json!({ "id": "state-1", "type": "get_state" })).await?;
+        if !config.prompt.trim().is_empty() {
+            Self::send_prompt(&stdin, config.prompt.clone(), &busy).await?;
+        }
+
+        let stdout_busy = busy.clone();
+        let stdout_tx = event_tx.clone();
+        tokio::spawn(async move {
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+            loop {
+                match lines.next_line().await {
+                    Ok(Some(line)) => {
+                        let line = line.trim();
+                        if line.is_empty() {
+                            continue;
+                        }
+                        if let Ok(value) = serde_json::from_str::<Value>(line) {
+                            match value.get("type").and_then(Value::as_str) {
+                                Some("agent_start") | Some("turn_start") => {
+                                    stdout_busy.store(true, Ordering::SeqCst);
+                                }
+                                Some("agent_end") => {
+                                    stdout_busy.store(false, Ordering::SeqCst);
+                                }
+                                _ => {}
+                            }
+                        }
+                        match Self::parse_event_line(line) {
+                            Ok(events) => {
+                                for event in events {
+                                    if stdout_tx.send(event).await.is_err() {
+                                        break;
+                                    }
+                                }
+                            }
+                            Err(_) => {
+                                if stdout_tx
+                                    .send(AgentEvent::Error(ErrorEvent {
+                                        message: format!("Failed to parse Pi event: {line}"),
+                                        is_fatal: false,
+                                        code: Some("pi_parse_error".to_string()),
+                                        details: None,
+                                    }))
+                                    .await
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(err) => {
+                        let _ = stdout_tx
+                            .send(AgentEvent::Error(ErrorEvent {
+                                message: format!("Failed reading Pi output: {err}"),
+                                is_fatal: true,
+                                code: Some("pi_stdout_error".to_string()),
+                                details: None,
+                            }))
+                            .await;
+                        break;
+                    }
+                }
+            }
+        });
+
+        let stderr_tx = event_tx.clone();
+        tokio::spawn(async move {
+            let reader = BufReader::new(stderr);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                if stderr_tx
+                    .send(AgentEvent::Error(ErrorEvent {
+                        message: format!("Pi stderr: {trimmed}"),
+                        is_fatal: false,
+                        code: Some("pi_stderr".to_string()),
+                        details: None,
+                    }))
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+            }
+        });
+
+        let input_stdin = stdin.clone();
+        let input_busy = busy.clone();
+        let input_event_tx = event_tx.clone();
+        tokio::spawn(async move {
+            while let Some(input) = input_rx.recv().await {
+                match input {
+                    AgentInput::CodexPrompt { text, images, .. } => {
+                        if !images.is_empty() {
+                            if input_event_tx
+                                .send(AgentEvent::Error(ErrorEvent {
+                                    message: "Image attachments are not supported for Pi sessions"
+                                        .to_string(),
+                                    is_fatal: false,
+                                    code: Some("pi_images_unsupported".to_string()),
+                                    details: None,
+                                }))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                            continue;
+                        }
+                        if let Err(err) = Self::send_prompt(&input_stdin, text, &input_busy).await {
+                            if input_event_tx
+                                .send(AgentEvent::Error(ErrorEvent {
+                                    message: err.to_string(),
+                                    is_fatal: true,
+                                    code: Some("pi_send_input".to_string()),
+                                    details: None,
+                                }))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    AgentInput::ClaudeJsonl(_) | AgentInput::OpencodeQuestion { .. } => {
+                        if input_event_tx
+                            .send(AgentEvent::Error(ErrorEvent {
+                                message: "Unsupported input for Pi runner".to_string(),
+                                is_fatal: false,
+                                code: Some("pi_input_unsupported".to_string()),
+                                details: None,
+                            }))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        tokio::spawn(async move {
+            match child.wait().await {
+                Ok(status) if status.success() => {}
+                Ok(status) => {
+                    let code = status.code();
+                    let _ = event_tx
+                        .send(AgentEvent::Error(ErrorEvent {
+                            message: format!("Pi exited with status {:?}", code),
+                            is_fatal: true,
+                            code: Some("pi_exit".to_string()),
+                            details: None,
+                        }))
+                        .await;
+                    if let Some(code) = code {
+                        let _ = event_tx
+                            .send(AgentEvent::TurnFailed(TurnFailedEvent {
+                                error: format!("Pi exited with status {code}"),
+                            }))
+                            .await;
+                    }
+                }
+                Err(err) => {
+                    let _ = event_tx
+                        .send(AgentEvent::Error(ErrorEvent {
+                            message: format!("Failed waiting for Pi process: {err}"),
+                            is_fatal: true,
+                            code: Some("pi_wait_error".to_string()),
+                            details: None,
+                        }))
+                        .await;
+                }
+            }
+        });
+
+        Ok(AgentHandle::new(event_rx, pid, Some(input_tx)))
     }
 
-    async fn send_input(
-        &self,
-        _handle: &AgentHandle,
-        _input: AgentInput,
-    ) -> Result<(), AgentError> {
-        Err(AgentError::NotSupported(
-            "Pi runner is not implemented yet".to_string(),
-        ))
+    async fn send_input(&self, handle: &AgentHandle, input: AgentInput) -> Result<(), AgentError> {
+        let sender = handle.input_tx.as_ref().ok_or(AgentError::ChannelClosed)?;
+        sender
+            .send(input)
+            .await
+            .map_err(|_| AgentError::ChannelClosed)
     }
 
-    async fn stop(&self, _handle: &AgentHandle) -> Result<(), AgentError> {
-        Ok(())
+    async fn stop(&self, handle: &AgentHandle) -> Result<(), AgentError> {
+        #[cfg(unix)]
+        {
+            return Self::signal_pid(handle.pid, libc::SIGTERM);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = handle;
+            Ok(())
+        }
     }
 
-    async fn kill(&self, _handle: &AgentHandle) -> Result<(), AgentError> {
-        Ok(())
+    async fn kill(&self, handle: &AgentHandle) -> Result<(), AgentError> {
+        #[cfg(unix)]
+        {
+            return Self::signal_pid(handle.pid, libc::SIGKILL);
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = handle;
+            Ok(())
+        }
     }
 
     fn is_available(&self) -> bool {
@@ -66,5 +628,129 @@ impl AgentRunner for PiRunner {
 
     fn binary_path(&self) -> Option<PathBuf> {
         Some(self.binary_path.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::PiRunner;
+    use crate::agent::events::AgentEvent;
+
+    #[test]
+    fn parses_get_state_response_into_session_init() {
+        let events = PiRunner::parse_event_value(&json!({
+            "type": "response",
+            "command": "get_state",
+            "success": true,
+            "data": {
+                "sessionFile": "/tmp/pi-session.jsonl",
+                "sessionId": "session-123",
+                "model": { "id": "anthropic/claude-sonnet-4-20250514" }
+            }
+        }));
+
+        assert!(matches!(
+            &events[0],
+            AgentEvent::SessionInit(init)
+                if init.session_id.as_str() == "/tmp/pi-session.jsonl"
+                    && init.model.as_deref() == Some("anthropic/claude-sonnet-4-20250514")
+        ));
+    }
+
+    #[test]
+    fn parses_message_update_deltas() {
+        let text_events = PiRunner::parse_event_value(&json!({
+            "type": "message_update",
+            "assistantMessageEvent": {
+                "type": "text_delta",
+                "delta": "Hello"
+            }
+        }));
+        let thinking_events = PiRunner::parse_event_value(&json!({
+            "type": "message_update",
+            "assistantMessageEvent": {
+                "type": "thinking_delta",
+                "delta": "Analyzing"
+            }
+        }));
+
+        assert!(matches!(
+            &text_events[0],
+            AgentEvent::AssistantMessage(message) if message.text == "Hello" && !message.is_final
+        ));
+        assert!(matches!(
+            &thinking_events[0],
+            AgentEvent::AssistantReasoning(reasoning) if reasoning.text == "Analyzing"
+        ));
+    }
+
+    #[test]
+    fn parses_tool_events_and_turn_completion() {
+        let started = PiRunner::parse_event_value(&json!({
+            "type": "tool_execution_start",
+            "toolCallId": "call-1",
+            "toolName": "bash",
+            "args": { "command": "ls" }
+        }));
+        let completed = PiRunner::parse_event_value(&json!({
+            "type": "tool_execution_end",
+            "toolCallId": "call-1",
+            "toolName": "bash",
+            "args": { "command": "ls" },
+            "result": {
+                "content": [{ "type": "text", "text": "file.txt\n" }]
+            },
+            "isError": false
+        }));
+        let turn = PiRunner::parse_event_value(&json!({
+            "type": "turn_end",
+            "message": {
+                "usage": {
+                    "input": 12,
+                    "output": 8,
+                    "cacheRead": 3,
+                    "totalTokens": 20
+                },
+                "stopReason": "stop"
+            }
+        }));
+
+        assert!(matches!(
+            &started[0],
+            AgentEvent::ToolStarted(tool)
+                if tool.tool_name == "bash"
+                    && tool.tool_id == "call-1"
+                    && tool.arguments["command"] == "ls"
+        ));
+        assert!(completed
+            .iter()
+            .any(|event| matches!(event, AgentEvent::ToolCompleted(tool) if tool.tool_id == "call-1" && tool.success)));
+        assert!(completed.iter().any(|event| matches!(
+            event,
+            AgentEvent::CommandOutput(output) if output.command == "ls" && output.output == "file.txt\n" && !output.is_streaming
+        )));
+        assert!(matches!(
+            &turn[0],
+            AgentEvent::TurnCompleted(done)
+                if done.usage.input_tokens == 12
+                    && done.usage.output_tokens == 8
+                    && done.usage.cached_tokens == 3
+                    && done.usage.total_tokens == 20
+        ));
+    }
+
+    #[test]
+    fn parses_jsonl_lines() {
+        let events = PiRunner::parse_event_line(
+            r#"{"type":"message_end","message":{"role":"assistant","content":[]}}"#,
+        )
+        .expect("line should parse");
+
+        assert!(matches!(
+            &events[0],
+            AgentEvent::AssistantMessage(message) if message.is_final && message.text.is_empty()
+        ));
     }
 }

--- a/src/agent/pi.rs
+++ b/src/agent/pi.rs
@@ -375,12 +375,11 @@ impl PiRunner {
         }))
     }
 
-    fn build_prompt_payload(
+    fn build_message_payload(
+        command_type: &str,
         text: String,
         images: &[PathBuf],
-        busy: bool,
     ) -> Result<Value, AgentError> {
-        let command_type = if busy { "steer" } else { "prompt" };
         if images.is_empty() {
             return Ok(json!({ "type": command_type, "message": text }));
         }
@@ -396,6 +395,15 @@ impl PiRunner {
         }))
     }
 
+    fn build_prompt_payload(
+        text: String,
+        images: &[PathBuf],
+        busy: bool,
+    ) -> Result<Value, AgentError> {
+        let command_type = if busy { "steer" } else { "prompt" };
+        Self::build_message_payload(command_type, text, images)
+    }
+
     async fn send_prompt(
         stdin: &Arc<Mutex<tokio::process::ChildStdin>>,
         text: String,
@@ -403,6 +411,15 @@ impl PiRunner {
         busy: &Arc<AtomicBool>,
     ) -> Result<(), AgentError> {
         let payload = Self::build_prompt_payload(text, images, busy.load(Ordering::SeqCst))?;
+        Self::write_command_line(stdin, payload).await
+    }
+
+    async fn send_follow_up(
+        stdin: &Arc<Mutex<tokio::process::ChildStdin>>,
+        text: String,
+        images: &[PathBuf],
+    ) -> Result<(), AgentError> {
+        let payload = Self::build_message_payload("follow_up", text, images)?;
         Self::write_command_line(stdin, payload).await
     }
 
@@ -566,6 +583,22 @@ impl AgentRunner for PiRunner {
                                     message: err.to_string(),
                                     is_fatal: true,
                                     code: Some("pi_set_thinking_level".to_string()),
+                                    details: None,
+                                }))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                    }
+                    AgentInput::PiFollowUp { text, images } => {
+                        if let Err(err) = Self::send_follow_up(&input_stdin, text, &images).await {
+                            if input_event_tx
+                                .send(AgentEvent::Error(ErrorEvent {
+                                    message: err.to_string(),
+                                    is_fatal: true,
+                                    code: Some("pi_follow_up".to_string()),
                                     details: None,
                                 }))
                                 .await
@@ -742,6 +775,16 @@ mod tests {
         assert!(payload["images"][0]["data"]
             .as_str()
             .is_some_and(|data| !data.is_empty()));
+    }
+
+    #[test]
+    fn build_message_payload_supports_follow_up() {
+        let payload = PiRunner::build_message_payload("follow_up", "later".to_string(), &[])
+            .expect("payload should build");
+
+        assert_eq!(payload["type"], "follow_up");
+        assert_eq!(payload["message"], "later");
+        assert!(payload.get("images").is_none());
     }
 
     #[test]

--- a/src/agent/pi.rs
+++ b/src/agent/pi.rs
@@ -633,10 +633,72 @@ impl AgentRunner for PiRunner {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use serde_json::json;
 
     use super::PiRunner;
     use crate::agent::events::AgentEvent;
+    use crate::agent::{AgentStartConfig, ReasoningEffort, SessionId};
+
+    fn command_args(command: &tokio::process::Command) -> Vec<String> {
+        command
+            .as_std()
+            .get_args()
+            .map(|arg| arg.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn build_command_includes_resume_model_thinking_and_tools() {
+        let runner = PiRunner::with_path(PathBuf::from("/usr/bin/pi"));
+        let config = AgentStartConfig::new("hello", PathBuf::from("/tmp"))
+            .with_resume(SessionId::from_string("/tmp/pi-session.jsonl"))
+            .with_model("anthropic/claude-sonnet-4")
+            .with_reasoning_effort(ReasoningEffort::XHigh)
+            .with_tools(vec!["Bash".to_string(), "Read".to_string()]);
+
+        let command = runner.build_command(&config);
+        let args = command_args(&command);
+
+        assert_eq!(
+            args,
+            vec![
+                "--mode",
+                "rpc",
+                "--session",
+                "/tmp/pi-session.jsonl",
+                "--model",
+                "anthropic/claude-sonnet-4",
+                "--thinking",
+                "xhigh",
+                "--tools",
+                "bash,read",
+            ]
+        );
+    }
+
+    #[test]
+    fn response_failure_emits_error_and_turn_failed() {
+        let events = PiRunner::parse_event_value(&json!({
+            "type": "response",
+            "command": "set_thinking_level",
+            "success": false,
+            "error": "thinking unsupported"
+        }));
+
+        assert!(matches!(
+            &events[0],
+            AgentEvent::Error(error)
+                if error.message == "thinking unsupported"
+                    && error.is_fatal
+                    && error.code.as_deref() == Some("pi_response_set_thinking_level")
+        ));
+        assert!(matches!(
+            &events[1],
+            AgentEvent::TurnFailed(failed) if failed.error == "thinking unsupported"
+        ));
+    }
 
     #[test]
     fn parses_get_state_response_into_session_init() {

--- a/src/agent/pi.rs
+++ b/src/agent/pi.rs
@@ -752,6 +752,18 @@ mod tests {
     }
 
     #[test]
+    fn build_command_supports_off_thinking() {
+        let runner = PiRunner::with_path(PathBuf::from("/usr/bin/pi"));
+        let config = AgentStartConfig::new("hello", PathBuf::from("/tmp"))
+            .with_reasoning_effort(ReasoningEffort::Off);
+
+        let command = runner.build_command(&config);
+        let args = command_args(&command);
+
+        assert!(args.windows(2).any(|pair| pair == ["--thinking", "off"]));
+    }
+
+    #[test]
     fn build_prompt_payload_includes_images() {
         let tmp = tempfile::Builder::new()
             .prefix("conduit-pi-image-")

--- a/src/agent/pi.rs
+++ b/src/agent/pi.rs
@@ -1,0 +1,70 @@
+use std::path::PathBuf;
+
+use crate::agent::error::AgentError;
+use crate::agent::runner::{AgentHandle, AgentInput, AgentRunner, AgentStartConfig, AgentType};
+use async_trait::async_trait;
+
+pub struct PiRunner {
+    binary_path: PathBuf,
+}
+
+impl Default for PiRunner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl PiRunner {
+    pub fn new() -> Self {
+        Self {
+            binary_path: Self::find_binary().unwrap_or_else(|| PathBuf::from("pi")),
+        }
+    }
+
+    pub fn with_path(path: PathBuf) -> Self {
+        Self { binary_path: path }
+    }
+
+    fn find_binary() -> Option<PathBuf> {
+        which::which("pi").ok()
+    }
+}
+
+#[async_trait]
+impl AgentRunner for PiRunner {
+    fn agent_type(&self) -> AgentType {
+        AgentType::Pi
+    }
+
+    async fn start(&self, _config: AgentStartConfig) -> Result<AgentHandle, AgentError> {
+        Err(AgentError::NotSupported(
+            "Pi runner is not implemented yet".to_string(),
+        ))
+    }
+
+    async fn send_input(
+        &self,
+        _handle: &AgentHandle,
+        _input: AgentInput,
+    ) -> Result<(), AgentError> {
+        Err(AgentError::NotSupported(
+            "Pi runner is not implemented yet".to_string(),
+        ))
+    }
+
+    async fn stop(&self, _handle: &AgentHandle) -> Result<(), AgentError> {
+        Ok(())
+    }
+
+    async fn kill(&self, _handle: &AgentHandle) -> Result<(), AgentError> {
+        Ok(())
+    }
+
+    fn is_available(&self) -> bool {
+        self.binary_path.exists() || which::which(&self.binary_path).is_ok()
+    }
+
+    fn binary_path(&self) -> Option<PathBuf> {
+        Some(self.binary_path.clone())
+    }
+}

--- a/src/agent/pi.rs
+++ b/src/agent/pi.rs
@@ -554,6 +554,27 @@ impl AgentRunner for PiRunner {
                             }
                         }
                     }
+                    AgentInput::PiSetThinkingLevel { level } => {
+                        if let Err(err) = Self::write_command_line(
+                            &input_stdin,
+                            json!({ "type": "set_thinking_level", "level": level.as_str() }),
+                        )
+                        .await
+                        {
+                            if input_event_tx
+                                .send(AgentEvent::Error(ErrorEvent {
+                                    message: err.to_string(),
+                                    is_fatal: true,
+                                    code: Some("pi_set_thinking_level".to_string()),
+                                    details: None,
+                                }))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                    }
                     AgentInput::ClaudeJsonl(_) | AgentInput::OpencodeQuestion { .. } => {
                         if input_event_tx
                             .send(AgentEvent::Error(ErrorEvent {

--- a/src/agent/pi.rs
+++ b/src/agent/pi.rs
@@ -1,5 +1,6 @@
-use std::path::PathBuf;
-use std::process::Stdio;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::process::{Command as StdCommand, Stdio};
 use std::sync::{
     atomic::{AtomicBool, Ordering},
     Arc,
@@ -21,6 +22,25 @@ use crate::agent::events::{
 };
 use crate::agent::runner::{AgentHandle, AgentInput, AgentRunner, AgentStartConfig, AgentType};
 use crate::agent::session::SessionId;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PiModelCatalogEntry {
+    pub provider: String,
+    pub model_id: String,
+    pub context_window: i64,
+}
+
+impl PiModelCatalogEntry {
+    pub fn full_id(&self) -> String {
+        format!("{}/{}", self.provider, self.model_id)
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PiModelCatalog {
+    pub current_model_id: Option<String>,
+    pub models: Vec<PiModelCatalogEntry>,
+}
 
 pub struct PiRunner {
     binary_path: PathBuf,
@@ -48,6 +68,154 @@ impl PiRunner {
 
     fn find_binary() -> Option<PathBuf> {
         which::which("pi").ok()
+    }
+
+    pub fn load_model_catalog(binary_path: Option<PathBuf>) -> PiModelCatalog {
+        let binary = binary_path
+            .filter(|path| path.exists())
+            .or_else(Self::find_binary);
+        let Some(binary) = binary else {
+            return PiModelCatalog::default();
+        };
+
+        let mut catalog = match Self::discover_model_catalog(&binary) {
+            Ok(catalog) => catalog,
+            Err(err) => {
+                tracing::debug!(error = %err, binary = %binary.display(), "Failed to discover Pi models");
+                PiModelCatalog::default()
+            }
+        };
+
+        if let Some(current_model_id) = catalog.current_model_id.clone() {
+            let already_present = catalog
+                .models
+                .iter()
+                .any(|model| model.full_id() == current_model_id);
+            if !already_present {
+                if let Some((provider, model_id)) = current_model_id.split_once('/') {
+                    catalog.models.push(PiModelCatalogEntry {
+                        provider: provider.to_string(),
+                        model_id: model_id.to_string(),
+                        context_window: 200_000,
+                    });
+                }
+            }
+        }
+
+        catalog.models.sort_by_key(PiModelCatalogEntry::full_id);
+        catalog.models.dedup_by(|left, right| {
+            left.provider == right.provider && left.model_id == right.model_id
+        });
+        catalog
+    }
+
+    fn discover_model_catalog(binary: &Path) -> std::io::Result<PiModelCatalog> {
+        Ok(PiModelCatalog {
+            current_model_id: Self::discover_current_model(binary)?,
+            models: Self::discover_available_models(binary)?,
+        })
+    }
+
+    fn discover_available_models(binary: &Path) -> std::io::Result<Vec<PiModelCatalogEntry>> {
+        let output = StdCommand::new(binary).arg("--list-models").output()?;
+        if !output.status.success() {
+            return Err(std::io::Error::other(format!(
+                "pi --list-models exited with status {:?}",
+                output.status.code()
+            )));
+        }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let text = if stdout.trim().is_empty() {
+            stderr.as_ref()
+        } else {
+            stdout.as_ref()
+        };
+        Ok(Self::parse_list_models_output(text))
+    }
+
+    fn discover_current_model(binary: &Path) -> std::io::Result<Option<String>> {
+        let mut child = StdCommand::new(binary)
+            .args(["--mode", "rpc", "--no-session"])
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()?;
+
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin.write_all(
+                br#"{"id":"state-1","type":"get_state"}
+"#,
+            )?;
+        }
+
+        let output = child.wait_with_output()?;
+        if !output.status.success() {
+            return Err(std::io::Error::other(format!(
+                "pi --mode rpc --no-session exited with status {:?}",
+                output.status.code()
+            )));
+        }
+
+        Ok(Self::parse_current_model_output(&String::from_utf8_lossy(
+            &output.stdout,
+        )))
+    }
+
+    fn parse_list_models_output(output: &str) -> Vec<PiModelCatalogEntry> {
+        output
+            .lines()
+            .skip_while(|line| line.trim().is_empty())
+            .skip(1)
+            .filter_map(|line| {
+                let mut parts = line.split_whitespace();
+                let provider = parts.next()?;
+                let model_id = parts.next()?;
+                let context_window = parts
+                    .next()
+                    .and_then(Self::parse_token_count)
+                    .unwrap_or(200_000);
+                Some(PiModelCatalogEntry {
+                    provider: provider.to_string(),
+                    model_id: model_id.to_string(),
+                    context_window,
+                })
+            })
+            .collect()
+    }
+
+    fn parse_current_model_output(output: &str) -> Option<String> {
+        output.lines().find_map(|line| {
+            let value: Value = serde_json::from_str(line).ok()?;
+            if value.get("type").and_then(Value::as_str) != Some("response")
+                || value.get("command").and_then(Value::as_str) != Some("get_state")
+                || value.get("success").and_then(Value::as_bool) != Some(true)
+            {
+                return None;
+            }
+
+            let model = value.get("data")?.get("model")?;
+            let provider = model.get("provider")?.as_str()?;
+            let model_id = model.get("id")?.as_str()?;
+            Some(format!("{provider}/{model_id}"))
+        })
+    }
+
+    fn parse_token_count(value: &str) -> Option<i64> {
+        let trimmed = value.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        let suffix = trimmed.chars().last()?;
+        let multiplier = match suffix {
+            'K' | 'k' => 1_000_f64,
+            'M' | 'm' => 1_000_000_f64,
+            _ => return trimmed.parse::<i64>().ok(),
+        };
+        let number = trimmed[..trimmed.len().saturating_sub(1)]
+            .parse::<f64>()
+            .ok()?;
+        Some((number * multiplier).round() as i64)
     }
 
     fn build_command(&self, config: &AgentStartConfig) -> Command {

--- a/src/agent/pi.rs
+++ b/src/agent/pi.rs
@@ -6,6 +6,8 @@ use std::sync::{
 };
 
 use async_trait::async_trait;
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine as _;
 use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
@@ -360,16 +362,47 @@ impl PiRunner {
         Ok(())
     }
 
+    fn image_payload(image: &PathBuf) -> Result<Value, AgentError> {
+        let bytes = std::fs::read(image)?;
+        let mime_type = mime_guess::from_path(image)
+            .first_or_octet_stream()
+            .essence_str()
+            .to_string();
+        Ok(json!({
+            "type": "image",
+            "data": BASE64_STANDARD.encode(bytes),
+            "mimeType": mime_type,
+        }))
+    }
+
+    fn build_prompt_payload(
+        text: String,
+        images: &[PathBuf],
+        busy: bool,
+    ) -> Result<Value, AgentError> {
+        let command_type = if busy { "steer" } else { "prompt" };
+        if images.is_empty() {
+            return Ok(json!({ "type": command_type, "message": text }));
+        }
+
+        let images = images
+            .iter()
+            .map(Self::image_payload)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(json!({
+            "type": command_type,
+            "message": text,
+            "images": images,
+        }))
+    }
+
     async fn send_prompt(
         stdin: &Arc<Mutex<tokio::process::ChildStdin>>,
         text: String,
+        images: &[PathBuf],
         busy: &Arc<AtomicBool>,
     ) -> Result<(), AgentError> {
-        let payload = if busy.load(Ordering::SeqCst) {
-            json!({ "type": "steer", "message": text })
-        } else {
-            json!({ "type": "prompt", "message": text })
-        };
+        let payload = Self::build_prompt_payload(text, images, busy.load(Ordering::SeqCst))?;
         Self::write_command_line(stdin, payload).await
     }
 
@@ -406,8 +439,8 @@ impl AgentRunner for PiRunner {
         let (input_tx, mut input_rx) = mpsc::channel(32);
 
         Self::write_command_line(&stdin, json!({ "id": "state-1", "type": "get_state" })).await?;
-        if !config.prompt.trim().is_empty() {
-            Self::send_prompt(&stdin, config.prompt.clone(), &busy).await?;
+        if !config.prompt.trim().is_empty() || !config.images.is_empty() {
+            Self::send_prompt(&stdin, config.prompt.clone(), &config.images, &busy).await?;
         }
 
         let stdout_busy = busy.clone();
@@ -504,23 +537,9 @@ impl AgentRunner for PiRunner {
             while let Some(input) = input_rx.recv().await {
                 match input {
                     AgentInput::CodexPrompt { text, images, .. } => {
-                        if !images.is_empty() {
-                            if input_event_tx
-                                .send(AgentEvent::Error(ErrorEvent {
-                                    message: "Image attachments are not supported for Pi sessions"
-                                        .to_string(),
-                                    is_fatal: false,
-                                    code: Some("pi_images_unsupported".to_string()),
-                                    details: None,
-                                }))
-                                .await
-                                .is_err()
-                            {
-                                break;
-                            }
-                            continue;
-                        }
-                        if let Err(err) = Self::send_prompt(&input_stdin, text, &input_busy).await {
+                        if let Err(err) =
+                            Self::send_prompt(&input_stdin, text, &images, &input_busy).await
+                        {
                             if input_event_tx
                                 .send(AgentEvent::Error(ErrorEvent {
                                     message: err.to_string(),
@@ -676,6 +695,32 @@ mod tests {
                 "bash,read",
             ]
         );
+    }
+
+    #[test]
+    fn build_prompt_payload_includes_images() {
+        let tmp = tempfile::Builder::new()
+            .prefix("conduit-pi-image-")
+            .suffix(".png")
+            .tempfile()
+            .expect("failed to create temp image");
+        let path = tmp.path().to_path_buf();
+        let img = image::RgbaImage::from_pixel(1, 1, image::Rgba([0, 0, 0, 255]));
+        image::DynamicImage::ImageRgba8(img)
+            .save(&path)
+            .expect("failed to write temp image");
+
+        let payload = PiRunner::build_prompt_payload("describe".to_string(), &[path], false)
+            .expect("payload should build");
+
+        assert_eq!(payload["type"], "prompt");
+        assert_eq!(payload["message"], "describe");
+        assert_eq!(payload["images"].as_array().map(Vec::len), Some(1));
+        assert_eq!(payload["images"][0]["type"], "image");
+        assert_eq!(payload["images"][0]["mimeType"], "image/png");
+        assert!(payload["images"][0]["data"]
+            .as_str()
+            .is_some_and(|data| !data.is_empty()));
     }
 
     #[test]

--- a/src/agent/pi.rs
+++ b/src/agent/pi.rs
@@ -33,6 +33,9 @@ impl Default for PiRunner {
 }
 
 impl PiRunner {
+    const DEFAULT_MODEL_ID: &str = "default";
+    const SUPPORTED_TOOLS: [&str; 7] = ["read", "bash", "edit", "write", "grep", "find", "ls"];
+
     pub fn new() -> Self {
         Self {
             binary_path: Self::find_binary().unwrap_or_else(|| PathBuf::from("pi")),
@@ -59,19 +62,21 @@ impl PiRunner {
             cmd.arg("--session").arg(session_id.as_str());
         }
         if let Some(model) = &config.model {
-            cmd.arg("--model").arg(model);
+            if !model.trim().eq_ignore_ascii_case(Self::DEFAULT_MODEL_ID) {
+                cmd.arg("--model").arg(model);
+            }
         }
         if let Some(effort) = config.reasoning_effort {
             cmd.arg("--thinking").arg(effort.as_str());
         }
-        if !config.allowed_tools.is_empty() {
-            let tools = config
-                .allowed_tools
-                .iter()
-                .map(|tool| tool.trim().to_ascii_lowercase())
-                .collect::<Vec<_>>()
-                .join(",");
-            cmd.arg("--tools").arg(tools);
+        let tools = config
+            .allowed_tools
+            .iter()
+            .map(|tool| tool.trim().to_ascii_lowercase())
+            .filter(|tool| Self::SUPPORTED_TOOLS.contains(&tool.as_str()))
+            .collect::<Vec<_>>();
+        if !tools.is_empty() {
+            cmd.arg("--tools").arg(tools.join(","));
         }
         for arg in &config.additional_args {
             cmd.arg(arg);
@@ -230,10 +235,36 @@ impl PiRunner {
             return Vec::new();
         }
 
+        let text = message
+            .get("content")
+            .map(Self::extract_text_from_message_content)
+            .filter(|text| !text.is_empty())
+            .or_else(|| {
+                message
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .map(str::to_string)
+                    .filter(|text| !text.is_empty())
+            })
+            .unwrap_or_default();
+
         vec![AgentEvent::AssistantMessage(AssistantMessageEvent {
-            text: String::new(),
+            text,
             is_final: true,
         })]
+    }
+
+    fn extract_text_from_message_content(content: &Value) -> String {
+        match content {
+            Value::String(text) => text.clone(),
+            Value::Array(blocks) => blocks
+                .iter()
+                .filter(|block| block.get("type").and_then(Value::as_str) == Some("text"))
+                .filter_map(|block| block.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n"),
+            _ => String::new(),
+        }
     }
 
     fn parse_tool_execution_start(value: &Value) -> Vec<AgentEvent> {
@@ -773,6 +804,36 @@ mod tests {
     }
 
     #[test]
+    fn build_command_omits_pi_default_model_argument() {
+        let runner = PiRunner::with_path(PathBuf::from("/usr/bin/pi"));
+        let config = AgentStartConfig::new("hello", PathBuf::from("/tmp"))
+            .with_model("default")
+            .with_tools(vec!["Read".to_string()]);
+
+        let command = runner.build_command(&config);
+        let args = command_args(&command);
+
+        assert_eq!(args, vec!["--mode", "rpc", "--tools", "read"]);
+    }
+
+    #[test]
+    fn build_command_filters_unsupported_tools() {
+        let runner = PiRunner::with_path(PathBuf::from("/usr/bin/pi"));
+        let config = AgentStartConfig::new("hello", PathBuf::from("/tmp")).with_tools(vec![
+            "Bash".to_string(),
+            "Glob".to_string(),
+            "Read".to_string(),
+            "Unknown".to_string(),
+            "Find".to_string(),
+        ]);
+
+        let command = runner.build_command(&config);
+        let args = command_args(&command);
+
+        assert_eq!(args, vec!["--mode", "rpc", "--tools", "bash,read,find"]);
+    }
+
+    #[test]
     fn build_command_supports_off_thinking() {
         let runner = PiRunner::with_path(PathBuf::from("/usr/bin/pi"));
         let config = AgentStartConfig::new("hello", PathBuf::from("/tmp"))
@@ -966,6 +1027,42 @@ mod tests {
         assert!(matches!(
             &events[0],
             AgentEvent::AssistantMessage(message) if message.is_final && message.text.is_empty()
+        ));
+    }
+
+    #[test]
+    fn parses_message_end_text_from_content_blocks() {
+        let events = PiRunner::parse_event_value(&json!({
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "content": [
+                    { "type": "text", "text": "Yes — everything appears committed." }
+                ]
+            }
+        }));
+
+        assert!(matches!(
+            &events[0],
+            AgentEvent::AssistantMessage(message)
+                if message.is_final && message.text == "Yes — everything appears committed."
+        ));
+    }
+
+    #[test]
+    fn parses_message_end_text_field_when_content_missing() {
+        let events = PiRunner::parse_event_value(&json!({
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "text": "Final answer"
+            }
+        }));
+
+        assert!(matches!(
+            &events[0],
+            AgentEvent::AssistantMessage(message)
+                if message.is_final && message.text == "Final answer"
         ));
     }
 }

--- a/src/agent/pi.rs
+++ b/src/agent/pi.rs
@@ -608,6 +608,27 @@ impl AgentRunner for PiRunner {
                             }
                         }
                     }
+                    AgentInput::PiSetFollowUpMode { mode } => {
+                        if let Err(err) = Self::write_command_line(
+                            &input_stdin,
+                            json!({ "type": "set_follow_up_mode", "mode": mode.as_str() }),
+                        )
+                        .await
+                        {
+                            if input_event_tx
+                                .send(AgentEvent::Error(ErrorEvent {
+                                    message: err.to_string(),
+                                    is_fatal: true,
+                                    code: Some("pi_set_follow_up_mode".to_string()),
+                                    details: None,
+                                }))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                    }
                     AgentInput::ClaudeJsonl(_) | AgentInput::OpencodeQuestion { .. } => {
                         if input_event_tx
                             .send(AgentEvent::Error(ErrorEvent {
@@ -712,7 +733,7 @@ mod tests {
 
     use super::PiRunner;
     use crate::agent::events::AgentEvent;
-    use crate::agent::{AgentStartConfig, ReasoningEffort, SessionId};
+    use crate::agent::{AgentStartConfig, PiFollowUpMode, ReasoningEffort, SessionId};
 
     fn command_args(command: &tokio::process::Command) -> Vec<String> {
         command
@@ -797,6 +818,17 @@ mod tests {
         assert_eq!(payload["type"], "follow_up");
         assert_eq!(payload["message"], "later");
         assert!(payload.get("images").is_none());
+    }
+
+    #[test]
+    fn build_set_follow_up_mode_payload() {
+        let payload = json!({
+            "type": "set_follow_up_mode",
+            "mode": PiFollowUpMode::OneAtATime.as_str(),
+        });
+
+        assert_eq!(payload["type"], "set_follow_up_mode");
+        assert_eq!(payload["mode"], "one-at-a-time");
     }
 
     #[test]

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -41,6 +41,18 @@ pub enum ReasoningEffort {
 }
 
 impl ReasoningEffort {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "off" => Some(ReasoningEffort::Off),
+            "minimal" => Some(ReasoningEffort::Minimal),
+            "low" => Some(ReasoningEffort::Low),
+            "medium" => Some(ReasoningEffort::Medium),
+            "high" => Some(ReasoningEffort::High),
+            "xhigh" => Some(ReasoningEffort::XHigh),
+            _ => None,
+        }
+    }
+
     pub fn as_str(self) -> &'static str {
         match self {
             ReasoningEffort::Off => "off",

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -292,6 +292,8 @@ pub enum AgentInput {
     },
     /// Pi-specific thinking level update for a live session.
     PiSetThinkingLevel { level: ReasoningEffort },
+    /// Pi-native follow-up message for a live session.
+    PiFollowUp { text: String, images: Vec<PathBuf> },
     /// OpenCode question response (None means reject).
     OpencodeQuestion {
         request_id: String,

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -15,6 +15,7 @@ pub enum AgentType {
     Codex,
     Gemini,
     Opencode,
+    Pi,
 }
 
 /// Agent mode (Build vs Plan)
@@ -117,12 +118,13 @@ impl AgentMode {
 
 impl AgentType {
     /// Preferred provider priority order used for defaults and UI listing.
-    pub const fn preferred_order() -> [AgentType; 4] {
+    pub const fn preferred_order() -> [AgentType; 5] {
         [
             AgentType::Codex,
             AgentType::Claude,
             AgentType::Gemini,
             AgentType::Opencode,
+            AgentType::Pi,
         ]
     }
 
@@ -139,6 +141,7 @@ impl AgentType {
             AgentType::Codex => "codex",
             AgentType::Gemini => "gemini",
             AgentType::Opencode => "opencode",
+            AgentType::Pi => "pi",
         }
     }
 
@@ -147,6 +150,7 @@ impl AgentType {
             "codex" => AgentType::Codex,
             "gemini" => AgentType::Gemini,
             "opencode" => AgentType::Opencode,
+            "pi" => AgentType::Pi,
             _ => AgentType::Claude,
         }
     }
@@ -158,6 +162,7 @@ impl AgentType {
             AgentType::Codex => "Codex",
             AgentType::Gemini => "Gemini",
             AgentType::Opencode => "OpenCode",
+            AgentType::Pi => "Pi",
         }
     }
 
@@ -167,6 +172,7 @@ impl AgentType {
             AgentType::Codex => "Codex CLI",
             AgentType::Gemini => "Gemini CLI",
             AgentType::Opencode => "OpenCode",
+            AgentType::Pi => "Pi",
         }
     }
 }
@@ -349,4 +355,19 @@ pub trait AgentRunner: Send + Sync {
 
     /// Get the path to the agent binary
     fn binary_path(&self) -> Option<PathBuf>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AgentType;
+
+    #[test]
+    fn pi_agent_type_has_public_identifiers() {
+        assert_eq!(AgentType::parse("pi"), AgentType::Pi);
+        assert_eq!(AgentType::Pi.as_str(), "pi");
+        assert_eq!(AgentType::Pi.short_name(), "Pi");
+        assert_eq!(AgentType::Pi.display_name(), "Pi");
+        assert!(!AgentType::Pi.supports_plan_mode());
+        assert!(AgentType::preferred_order().contains(&AgentType::Pi));
+    }
 }

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -40,6 +40,29 @@ pub enum ReasoningEffort {
     XHigh,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PiFollowUpMode {
+    All,
+    OneAtATime,
+}
+
+impl PiFollowUpMode {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "all" => Some(PiFollowUpMode::All),
+            "one-at-a-time" => Some(PiFollowUpMode::OneAtATime),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PiFollowUpMode::All => "all",
+            PiFollowUpMode::OneAtATime => "one-at-a-time",
+        }
+    }
+}
+
 impl ReasoningEffort {
     pub fn parse(value: &str) -> Option<Self> {
         match value.trim().to_ascii_lowercase().as_str() {
@@ -309,6 +332,8 @@ pub enum AgentInput {
     PiSetThinkingLevel { level: ReasoningEffort },
     /// Pi-native follow-up message for a live session.
     PiFollowUp { text: String, images: Vec<PathBuf> },
+    /// Pi-specific follow-up queue mode for a live session.
+    PiSetFollowUpMode { mode: PiFollowUpMode },
     /// OpenCode question response (None means reject).
     OpencodeQuestion {
         request_id: String,

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -283,13 +283,15 @@ impl AgentStartConfig {
 pub enum AgentInput {
     /// Raw JSONL payload for Claude streaming input.
     ClaudeJsonl(String),
-    /// Codex prompt with optional local images and model override.
+    /// Codex-style prompt with optional local images and model override.
     CodexPrompt {
         text: String,
         images: Vec<PathBuf>,
         model: Option<String>,
         skill: Option<SkillReference>,
     },
+    /// Pi-specific thinking level update for a live session.
+    PiSetThinkingLevel { level: ReasoningEffort },
     /// OpenCode question response (None means reject).
     OpencodeQuestion {
         request_id: String,

--- a/src/agent/runner.rs
+++ b/src/agent/runner.rs
@@ -32,6 +32,7 @@ pub enum AgentMode {
 /// Provider-agnostic reasoning effort profile.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ReasoningEffort {
+    Off,
     Minimal,
     Low,
     Medium,
@@ -42,6 +43,7 @@ pub enum ReasoningEffort {
 impl ReasoningEffort {
     pub fn as_str(self) -> &'static str {
         match self {
+            ReasoningEffort::Off => "off",
             ReasoningEffort::Minimal => "minimal",
             ReasoningEffort::Low => "low",
             ReasoningEffort::Medium => "medium",
@@ -52,6 +54,7 @@ impl ReasoningEffort {
 
     pub fn display_name(self) -> &'static str {
         match self {
+            ReasoningEffort::Off => "Off",
             ReasoningEffort::Minimal => "Minimal",
             ReasoningEffort::Low => "Low",
             ReasoningEffort::Medium => "Medium",
@@ -65,7 +68,7 @@ impl ReasoningEffort {
             ReasoningEffort::Low => Some("low"),
             ReasoningEffort::Medium => Some("medium"),
             ReasoningEffort::High => Some("high"),
-            ReasoningEffort::Minimal | ReasoningEffort::XHigh => None,
+            ReasoningEffort::Off | ReasoningEffort::Minimal | ReasoningEffort::XHigh => None,
         }
     }
 

--- a/src/command_resolver.rs
+++ b/src/command_resolver.rs
@@ -369,7 +369,7 @@ fn render_skill_invocation(
             codex_skill: None,
             source_badge: Some(format!("{} skill", source.display_name())),
         },
-        AgentType::Gemini | AgentType::Opencode | AgentType::Claude => {
+        AgentType::Gemini | AgentType::Opencode | AgentType::Pi | AgentType::Claude => {
             let task = if args.is_empty() {
                 "Use it for the user's current request.".to_string()
             } else {

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1117,6 +1117,9 @@ mod tests {
             config.effective_enabled_providers(&tools),
             vec![AgentType::Pi]
         );
-        assert_eq!(config.default_model_for(AgentType::Pi), "default");
+        assert_eq!(
+            config.default_model_for(AgentType::Pi),
+            ModelRegistry::default_model(AgentType::Pi)
+        );
     }
 }

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -614,6 +614,7 @@ impl Config {
             "codex" => Some(AgentType::Codex),
             "gemini" => Some(AgentType::Gemini),
             "opencode" => Some(AgentType::Opencode),
+            "pi" => Some(AgentType::Pi),
             _ => None,
         }
     }
@@ -788,6 +789,7 @@ impl Config {
             AgentType::Codex => Tool::Codex,
             AgentType::Gemini => Tool::Gemini,
             AgentType::Opencode => Tool::Opencode,
+            AgentType::Pi => Tool::Pi,
         }
     }
 
@@ -1095,5 +1097,26 @@ mod tests {
             COMMAND_NAMES.contains(&"handoff_session"),
             "handoff_session should be present in COMMAND_NAMES"
         );
+    }
+
+    #[test]
+    fn test_parse_provider_pi() {
+        assert_eq!(Config::parse_provider("pi"), Some(AgentType::Pi));
+    }
+
+    #[test]
+    fn test_effective_enabled_providers_includes_pi_when_available() {
+        let mut tools = ToolAvailability::default();
+        let executable = std::env::current_exe().expect("current test executable path");
+        assert!(tools.update_tool(Tool::Pi, executable));
+
+        let mut config = Config::default();
+        config.enabled_providers = Some(vec![AgentType::Pi]);
+
+        assert_eq!(
+            config.effective_enabled_providers(&tools),
+            vec![AgentType::Pi]
+        );
+        assert_eq!(config.default_model_for(AgentType::Pi), "default");
     }
 }

--- a/src/core/conduit_core.rs
+++ b/src/core/conduit_core.rs
@@ -121,6 +121,12 @@ impl ConduitCore {
             ModelRegistry::clear_opencode_models();
         }
 
+        if tools.is_available(Tool::Pi) {
+            ModelRegistry::set_pi_models(tools.get_path(Tool::Pi).cloned());
+        } else {
+            ModelRegistry::clear_pi_models();
+        }
+
         Self {
             config,
             tools,
@@ -277,6 +283,12 @@ impl ConduitCore {
             ModelRegistry::set_opencode_models(models);
         } else {
             ModelRegistry::clear_opencode_models();
+        }
+
+        if self.tools.is_available(Tool::Pi) {
+            ModelRegistry::set_pi_models(self.tools.get_path(Tool::Pi).cloned());
+        } else {
+            ModelRegistry::clear_pi_models();
         }
     }
 }

--- a/src/core/conduit_core.rs
+++ b/src/core/conduit_core.rs
@@ -3,7 +3,7 @@
 use std::sync::Arc;
 
 use crate::agent::{
-    ClaudeCodeRunner, CodexCliRunner, GeminiCliRunner, ModelRegistry, OpencodeRunner,
+    ClaudeCodeRunner, CodexCliRunner, GeminiCliRunner, ModelRegistry, OpencodeRunner, PiRunner,
 };
 use crate::config::Config;
 use crate::data::{
@@ -44,6 +44,8 @@ pub struct ConduitCore {
     gemini_runner: Arc<GeminiCliRunner>,
     /// OpenCode runner
     opencode_runner: Arc<OpencodeRunner>,
+    /// Pi runner
+    pi_runner: Arc<PiRunner>,
     /// Worktree manager
     worktree_manager: WorkspaceRepoManager,
 }
@@ -105,6 +107,10 @@ impl ConduitCore {
             Some(path) => Arc::new(OpencodeRunner::with_path(path.clone())),
             None => Arc::new(OpencodeRunner::new()),
         };
+        let pi_runner = match tools.get_path(Tool::Pi) {
+            Some(path) => Arc::new(PiRunner::with_path(path.clone())),
+            None => Arc::new(PiRunner::new()),
+        };
 
         if tools.is_available(Tool::Opencode) {
             let models = crate::agent::opencode::load_opencode_models(
@@ -128,6 +134,7 @@ impl ConduitCore {
             codex_runner,
             gemini_runner,
             opencode_runner,
+            pi_runner,
             worktree_manager,
         }
     }
@@ -212,6 +219,11 @@ impl ConduitCore {
         &self.opencode_runner
     }
 
+    /// Get the Pi runner.
+    pub fn pi_runner(&self) -> &Arc<PiRunner> {
+        &self.pi_runner
+    }
+
     /// Get the worktree manager.
     pub fn worktree_manager(&self) -> &WorkspaceRepoManager {
         &self.worktree_manager
@@ -252,6 +264,10 @@ impl ConduitCore {
         self.opencode_runner = match self.tools.get_path(Tool::Opencode) {
             Some(path) => Arc::new(OpencodeRunner::with_path(path.clone())),
             None => Arc::new(OpencodeRunner::new()),
+        };
+        self.pi_runner = match self.tools.get_path(Tool::Pi) {
+            Some(path) => Arc::new(PiRunner::with_path(path.clone())),
+            None => Arc::new(PiRunner::new()),
         };
 
         if self.tools.is_available(Tool::Opencode) {

--- a/src/core/services/config_service.rs
+++ b/src/core/services/config_service.rs
@@ -76,6 +76,7 @@ impl ConfigService {
                     AgentType::Codex => crate::util::Tool::Codex,
                     AgentType::Gemini => crate::util::Tool::Gemini,
                     AgentType::Opencode => crate::util::Tool::Opencode,
+                    AgentType::Pi => crate::util::Tool::Pi,
                 })
             })
             .count();

--- a/src/session/import.rs
+++ b/src/session/import.rs
@@ -129,6 +129,7 @@ pub fn discover_all_sessions() -> Vec<ExternalSession> {
     sessions.extend(discover_claude_sessions());
     sessions.extend(discover_codex_sessions());
     sessions.extend(discover_opencode_sessions());
+    sessions.extend(discover_pi_sessions());
 
     // Sort by timestamp descending (most recent first)
     sessions.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
@@ -231,6 +232,13 @@ fn scan_session_files() -> Vec<(PathBuf, u64)> {
         }
     }
 
+    // Scan Pi sessions
+    if let Some(pi_sessions_dir) = pi_sessions_dir() {
+        if pi_sessions_dir.exists() {
+            files.extend(scan_pi_session_files(&pi_sessions_dir));
+        }
+    }
+
     files
 }
 
@@ -246,6 +254,10 @@ fn opencode_storage_dir() -> Option<PathBuf> {
         candidates.push(home.join(".local/share/opencode/storage"));
     }
     candidates.into_iter().find(|path| path.exists())
+}
+
+fn pi_sessions_dir() -> Option<PathBuf> {
+    dirs::home_dir().map(|home| home.join(".pi").join("agent").join("sessions"))
 }
 
 /// Scan Claude session files from projects directory
@@ -363,6 +375,30 @@ fn scan_opencode_session_files(sessions_dir: &PathBuf) -> Vec<(PathBuf, u64)> {
     files
 }
 
+fn scan_pi_session_files(sessions_dir: &PathBuf) -> Vec<(PathBuf, u64)> {
+    let mut files = Vec::new();
+    if let Ok(project_entries) = fs::read_dir(sessions_dir) {
+        for project_entry in project_entries.flatten() {
+            let project_path = project_entry.path();
+            if !project_path.is_dir() {
+                continue;
+            }
+            if let Ok(session_entries) = fs::read_dir(&project_path) {
+                for session_entry in session_entries.flatten() {
+                    let path = session_entry.path();
+                    if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                        continue;
+                    }
+                    if let Some(mtime) = get_file_mtime(&path) {
+                        files.push((path, mtime));
+                    }
+                }
+            }
+        }
+    }
+    files
+}
+
 /// Read a single session file and return ExternalSession
 fn read_single_session(path: &PathBuf) -> Option<ExternalSession> {
     let home = dirs::home_dir()?;
@@ -375,6 +411,18 @@ fn read_single_session(path: &PathBuf) -> Option<ExternalSession> {
     } else if let Some(storage_dir) = opencode_storage_dir() {
         if path.starts_with(storage_dir.join("session")) {
             parse_opencode_session_file(path, &storage_dir)
+        } else if let Some(pi_dir) = pi_sessions_dir() {
+            if path.starts_with(&pi_dir) {
+                parse_pi_session_file(path)
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    } else if let Some(pi_dir) = pi_sessions_dir() {
+        if path.starts_with(&pi_dir) {
+            parse_pi_session_file(path)
         } else {
             None
         }
@@ -694,6 +742,40 @@ pub fn discover_opencode_sessions() -> Vec<ExternalSession> {
     sessions
 }
 
+/// Discover Pi sessions from ~/.pi/agent/sessions/<project>/<session>.jsonl
+pub fn discover_pi_sessions() -> Vec<ExternalSession> {
+    let sessions_dir = match pi_sessions_dir() {
+        Some(dir) => dir,
+        None => return Vec::new(),
+    };
+    if !sessions_dir.exists() {
+        return Vec::new();
+    }
+
+    let mut sessions = Vec::new();
+    if let Ok(project_entries) = fs::read_dir(&sessions_dir) {
+        for project_entry in project_entries.flatten() {
+            let project_path = project_entry.path();
+            if !project_path.is_dir() {
+                continue;
+            }
+            if let Ok(session_entries) = fs::read_dir(&project_path) {
+                for session_entry in session_entries.flatten() {
+                    let path = session_entry.path();
+                    if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+                        continue;
+                    }
+                    if let Some(session) = parse_pi_session_file(&path) {
+                        sessions.push(session);
+                    }
+                }
+            }
+        }
+    }
+
+    sessions
+}
+
 /// Parse a Codex session file and extract metadata
 fn parse_codex_session_file(path: &PathBuf) -> Option<ExternalSession> {
     let file = File::open(path).ok()?;
@@ -881,6 +963,102 @@ fn parse_opencode_session_file(path: &Path, storage_dir: &Path) -> Option<Extern
         message_count,
         file_path: path.to_path_buf(),
     })
+}
+
+fn parse_pi_session_file(path: &Path) -> Option<ExternalSession> {
+    let file = File::open(path).ok()?;
+    let reader = BufReader::new(file);
+
+    let mut session_id = path.file_stem()?.to_string_lossy().to_string();
+    let mut project: Option<String> = None;
+    let mut first_user_message = String::new();
+    let mut message_count = 0usize;
+    let mut timestamp: Option<DateTime<Utc>> = None;
+
+    for line in reader.lines() {
+        let line = line.ok()?;
+        if line.trim().is_empty() {
+            continue;
+        }
+        let entry: Value = serde_json::from_str(&line).ok()?;
+        match entry.get("type").and_then(Value::as_str) {
+            Some("session") => {
+                if let Some(id) = entry.get("id").and_then(Value::as_str) {
+                    session_id = id.to_string();
+                }
+                project = entry.get("cwd").and_then(Value::as_str).map(str::to_string);
+                if timestamp.is_none() {
+                    timestamp = entry
+                        .get("timestamp")
+                        .and_then(Value::as_str)
+                        .and_then(|ts| DateTime::parse_from_rfc3339(ts).ok())
+                        .map(|dt| dt.with_timezone(&Utc));
+                }
+            }
+            Some("message") => {
+                message_count += 1;
+                if first_user_message.is_empty()
+                    && entry
+                        .get("message")
+                        .and_then(|message| message.get("role"))
+                        .and_then(Value::as_str)
+                        == Some("user")
+                {
+                    first_user_message = extract_pi_text_content(entry.get("message")?);
+                }
+                timestamp = entry
+                    .get("timestamp")
+                    .and_then(Value::as_str)
+                    .and_then(|ts| DateTime::parse_from_rfc3339(ts).ok())
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .or(timestamp);
+            }
+            _ => {}
+        }
+    }
+
+    if message_count == 0 {
+        return None;
+    }
+
+    let timestamp = timestamp.unwrap_or_else(|| {
+        path.metadata()
+            .and_then(|m| m.modified())
+            .map(DateTime::<Utc>::from)
+            .unwrap_or_else(|_| Utc::now())
+    });
+
+    Some(ExternalSession {
+        id: session_id,
+        agent_type: AgentType::Pi,
+        display: if first_user_message.trim().is_empty() {
+            "(No title)".to_string()
+        } else {
+            first_user_message
+        },
+        project,
+        timestamp,
+        message_count,
+        file_path: path.to_path_buf(),
+    })
+}
+
+fn extract_pi_text_content(message: &Value) -> String {
+    match message.get("content") {
+        Some(Value::String(text)) => text.clone(),
+        Some(Value::Array(blocks)) => blocks
+            .iter()
+            .filter_map(|block| {
+                let block_type = block.get("type")?.as_str()?;
+                match block_type {
+                    "text" => block.get("text")?.as_str().map(str::to_string),
+                    _ => None,
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n"),
+        _ => String::new(),
+    }
 }
 
 /// Peek at a Claude session file to get message count and first user message
@@ -1193,5 +1371,41 @@ mod tests {
         };
 
         assert_eq!(session.project_name(), Some("my-project".to_string()));
+    }
+
+    #[test]
+    fn test_parse_pi_session_file_extracts_metadata() {
+        let temp = tempfile::TempDir::new().unwrap();
+        let session_file = temp.path().join("pi-session.jsonl");
+        fs::write(
+            &session_file,
+            [
+                serde_json::json!({
+                    "type": "session",
+                    "version": 3,
+                    "id": "pi-session-id",
+                    "timestamp": "2026-04-02T10:00:00.000Z",
+                    "cwd": "/tmp/pi-demo"
+                })
+                .to_string(),
+                serde_json::json!({
+                    "type": "message",
+                    "id": "a1",
+                    "parentId": null,
+                    "timestamp": "2026-04-02T10:00:01.000Z",
+                    "message": {"role": "user", "content": [{"type": "text", "text": "Hello from pi"}]}
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        )
+        .unwrap();
+
+        let session = parse_pi_session_file(&session_file).expect("pi session should parse");
+        assert_eq!(session.agent_type, AgentType::Pi);
+        assert_eq!(session.id, "pi-session-id");
+        assert_eq!(session.project.as_deref(), Some("/tmp/pi-demo"));
+        assert_eq!(session.display, "Hello from pi");
+        assert_eq!(session.file_path, session_file);
     }
 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -8139,11 +8139,7 @@ impl App {
         }
 
         // Start agent
-        if matches!(
-            agent_type,
-            AgentType::Gemini | AgentType::Opencode | AgentType::Pi
-        ) && !images.is_empty()
-        {
+        if matches!(agent_type, AgentType::Gemini | AgentType::Opencode) && !images.is_empty() {
             if let Some(session) = self.state.tab_manager.session_mut(tab_index) {
                 session.stop_processing();
                 session.pending_user_message = None;
@@ -8174,7 +8170,11 @@ impl App {
         // Strip placeholders for agents that send images out-of-band.
         if matches!(
             agent_type,
-            AgentType::Codex | AgentType::Claude | AgentType::Gemini | AgentType::Opencode
+            AgentType::Codex
+                | AgentType::Claude
+                | AgentType::Gemini
+                | AgentType::Opencode
+                | AgentType::Pi
         ) {
             agent_prompt = Self::strip_image_placeholders(agent_prompt, &image_placeholders);
         }
@@ -12290,6 +12290,61 @@ mod tests {
         assert_eq!(*agent_type, AgentType::Pi);
         assert_eq!(config.resume_session.as_ref(), Some(&saved_session));
         assert_eq!(config.prompt, "resume pi");
+    }
+
+    #[test]
+    fn test_submit_prompt_for_tab_allows_pi_images() {
+        let session_id = Uuid::new_v4();
+        let mut app = build_test_app_with_sessions(&[session_id]);
+        let cwd = std::env::current_dir().expect("cwd");
+        let default_model = app.config().default_model_for(AgentType::Pi);
+        let tmp = tempfile::Builder::new()
+            .prefix("conduit-pi-image-")
+            .suffix(".png")
+            .tempfile()
+            .expect("failed to create temp image");
+        let image_path = tmp.path().to_path_buf();
+        let img = image::RgbaImage::from_pixel(1, 1, image::Rgba([0, 0, 0, 255]));
+        image::DynamicImage::ImageRgba8(img)
+            .save(&image_path)
+            .expect("failed to write temp image");
+
+        {
+            let session = app
+                .state
+                .tab_manager
+                .session_by_id_mut(session_id)
+                .expect("session missing");
+            session.agent_type = AgentType::Pi;
+            session.model = Some(default_model);
+            session.model_invalid = false;
+            session.working_dir = Some(cwd);
+        }
+
+        let effects = app
+            .submit_prompt_for_tab(
+                0,
+                "describe image".to_string(),
+                vec![image_path.clone()],
+                vec!["@image.png".to_string()],
+                false,
+                None,
+            )
+            .expect("submit should succeed");
+
+        let (agent_type, config) = effects
+            .iter()
+            .find_map(|effect| match effect {
+                Effect::StartAgent {
+                    agent_type, config, ..
+                } => Some((agent_type, config)),
+                _ => None,
+            })
+            .expect("expected StartAgent effect");
+
+        assert_eq!(*agent_type, AgentType::Pi);
+        assert_eq!(config.images, vec![image_path]);
+        assert_eq!(config.prompt, "describe image");
     }
 
     #[test]

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -30,10 +30,10 @@ use uuid::Uuid;
 use crate::agent::events::UserQuestion;
 use crate::agent::{
     load_claude_history_with_debug, load_codex_history_with_debug,
-    load_opencode_history_for_dir_with_debug, load_opencode_history_with_debug, AgentEvent,
-    AgentInput, AgentMode, AgentRunner, AgentStartConfig, AgentType, ClaudeCodeRunner,
-    CodexCliRunner, GeminiCliRunner, HistoryDebugEntry, MessageDisplay, ModelRegistry,
-    OpencodeRunner, PiRunner, SessionId,
+    load_opencode_history_for_dir_with_debug, load_opencode_history_with_debug,
+    load_pi_history_with_debug, AgentEvent, AgentInput, AgentMode, AgentRunner, AgentStartConfig,
+    AgentType, ClaudeCodeRunner, CodexCliRunner, GeminiCliRunner, HistoryDebugEntry,
+    MessageDisplay, ModelRegistry, OpencodeRunner, PiRunner, SessionId,
 };
 use crate::command_resolver::{
     CommandResolver, ConduitCommand, MenuEntryKind, ResolveResult, ResolvedPrompt,
@@ -536,12 +536,18 @@ impl App {
                         );
                     }
                     AgentType::Pi => {
-                        session.chat_view.push(
-                            MessageDisplay::System {
-                                content: "Pi history import isn't supported yet, so previous messages won't be shown.".to_string(),
+                        if let Ok((msgs, debug_entries, file_path)) =
+                            load_pi_history_with_debug(session_id_str)
+                        {
+                            Self::populate_debug_from_history(
+                                &mut session.raw_events_view,
+                                &debug_entries,
+                                &file_path,
+                            );
+                            for msg in msgs {
+                                session.chat_view.push(msg);
                             }
-                            .to_chat_message(),
-                        );
+                        }
                     }
                     AgentType::Opencode => {
                         if let Ok((msgs, debug_entries, file_path)) =
@@ -3599,12 +3605,18 @@ impl App {
                             );
                         }
                         AgentType::Pi => {
-                            session.chat_view.push(
-                                MessageDisplay::System {
-                                    content: "Pi history import isn't supported yet, so previous messages won't be shown.".to_string(),
+                            if let Ok((msgs, debug_entries, file_path)) =
+                                load_pi_history_with_debug(session_id_str)
+                            {
+                                Self::populate_debug_from_history(
+                                    &mut session.raw_events_view,
+                                    &debug_entries,
+                                    &file_path,
+                                );
+                                for msg in msgs {
+                                    session.chat_view.push(msg);
                                 }
-                                .to_chat_message(),
-                            );
+                            }
                         }
                         AgentType::Opencode => {
                             if let Ok((msgs, debug_entries, file_path)) =
@@ -4927,17 +4939,20 @@ impl App {
         session_file: std::path::PathBuf,
         working_dir: std::path::PathBuf,
     ) -> anyhow::Result<()> {
-        // Extract session ID from the file path
-        let session_id_str = session_file
-            .file_stem()
-            .and_then(|n| n.to_str())
-            .unwrap_or("unknown")
-            .to_string();
+        let session_ref = if agent_type == AgentType::Pi {
+            session_file.to_string_lossy().to_string()
+        } else {
+            session_file
+                .file_stem()
+                .and_then(|n| n.to_str())
+                .unwrap_or("unknown")
+                .to_string()
+        };
 
         // Create a new session with working directory
         let mut session = AgentSession::with_working_dir(agent_type, working_dir);
         // Set both resume and agent session IDs so the session can be restored after restart
-        let session_id = SessionId::from_string(&session_id_str);
+        let session_id = SessionId::from_string(&session_ref);
         session.resume_session_id = Some(session_id.clone());
         if agent_type != AgentType::Codex {
             session.agent_session_id = Some(session_id);
@@ -4947,7 +4962,7 @@ impl App {
         match agent_type {
             AgentType::Claude => {
                 if let Ok((msgs, debug_entries, file_path)) =
-                    load_claude_history_with_debug(&session_id_str)
+                    load_claude_history_with_debug(&session_ref)
                 {
                     Self::populate_debug_from_history(
                         &mut session.raw_events_view,
@@ -4961,7 +4976,7 @@ impl App {
             }
             AgentType::Codex => {
                 if let Ok((msgs, debug_entries, file_path)) =
-                    load_codex_history_with_debug(&session_id_str)
+                    load_codex_history_with_debug(&session_ref)
                 {
                     Self::populate_debug_from_history(
                         &mut session.raw_events_view,
@@ -4984,18 +4999,22 @@ impl App {
                 );
             }
             AgentType::Pi => {
-                session.resume_session_id = None;
-                session.agent_session_id = None;
-                session.chat_view.push(
-                    MessageDisplay::System {
-                        content: "Pi session import isn't supported yet.".to_string(),
+                if let Ok((msgs, debug_entries, file_path)) =
+                    load_pi_history_with_debug(&session_ref)
+                {
+                    Self::populate_debug_from_history(
+                        &mut session.raw_events_view,
+                        &debug_entries,
+                        &file_path,
+                    );
+                    for msg in msgs {
+                        session.chat_view.push(msg);
                     }
-                    .to_chat_message(),
-                );
+                }
             }
             AgentType::Opencode => {
                 if let Ok((msgs, debug_entries, file_path)) =
-                    load_opencode_history_with_debug(&session_id_str)
+                    load_opencode_history_with_debug(&session_ref)
                 {
                     Self::populate_debug_from_history(
                         &mut session.raw_events_view,

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -13466,6 +13466,51 @@ mod tests {
             .contains("Changing reasoning effort after a session has started"));
     }
 
+    #[tokio::test]
+    async fn test_handle_confirm_action_selecting_reasoning_updates_live_pi_session() {
+        let session_id = Uuid::new_v4();
+        let mut app = build_test_app_with_sessions(&[session_id]);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        {
+            let session = app
+                .state
+                .tab_manager
+                .active_session_mut()
+                .expect("session missing");
+            session.agent_type = AgentType::Pi;
+            session.turn_count = 1;
+            session.agent_input_tx = Some(tx);
+        }
+        app.state.reasoning_selector_state.show(AgentType::Pi, None);
+        app.state.reasoning_selector_state.insert_str("high");
+        app.state.input_mode = InputMode::SelectingReasoning;
+
+        let mut effects = Vec::new();
+        app.handle_confirm_action(&mut effects).unwrap();
+
+        assert_eq!(app.state.input_mode, InputMode::Normal);
+        assert!(!app.state.reasoning_selector_state.is_visible());
+        assert!(effects.is_empty());
+
+        let session = app
+            .state
+            .tab_manager
+            .active_session()
+            .expect("session missing");
+        assert_eq!(session.reasoning_effort, Some(ReasoningEffort::High));
+
+        let input = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for Pi reasoning update")
+            .expect("input channel closed");
+        assert!(matches!(
+            input,
+            AgentInput::PiSetThinkingLevel {
+                level: ReasoningEffort::High
+            }
+        ));
+    }
+
     #[test]
     fn test_handle_confirm_action_blocks_cross_agent_switch_after_session_started() {
         let session_id = Uuid::new_v4();

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -13520,6 +13520,33 @@ mod tests {
     }
 
     #[test]
+    fn test_handle_confirm_action_selecting_reasoning_sets_pi_off() {
+        let session_id = Uuid::new_v4();
+        let mut app = build_test_app_with_sessions(&[session_id]);
+        {
+            let session = app
+                .state
+                .tab_manager
+                .active_session_mut()
+                .expect("session missing");
+            session.agent_type = AgentType::Pi;
+        }
+        app.state.reasoning_selector_state.show(AgentType::Pi, None);
+        app.state.reasoning_selector_state.insert_str("off");
+        app.state.input_mode = InputMode::SelectingReasoning;
+
+        let mut effects = Vec::new();
+        app.handle_confirm_action(&mut effects).unwrap();
+
+        let session = app
+            .state
+            .tab_manager
+            .active_session()
+            .expect("session missing");
+        assert_eq!(session.reasoning_effort, Some(ReasoningEffort::Off));
+    }
+
+    #[test]
     fn test_handle_confirm_action_model_selector_wins_over_stale_mode() {
         let mut app = build_test_app_with_sessions(&[]);
         let executable = std::env::current_exe().expect("test executable path");

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -33,7 +33,7 @@ use crate::agent::{
     load_opencode_history_for_dir_with_debug, load_opencode_history_with_debug, AgentEvent,
     AgentInput, AgentMode, AgentRunner, AgentStartConfig, AgentType, ClaudeCodeRunner,
     CodexCliRunner, GeminiCliRunner, HistoryDebugEntry, MessageDisplay, ModelRegistry,
-    OpencodeRunner, SessionId,
+    OpencodeRunner, PiRunner, SessionId,
 };
 use crate::command_resolver::{
     CommandResolver, ConduitCommand, MenuEntryKind, ResolveResult, ResolvedPrompt,
@@ -275,6 +275,12 @@ impl App {
     #[inline]
     fn opencode_runner(&self) -> &Arc<OpencodeRunner> {
         self.core.opencode_runner()
+    }
+
+    /// Get the Pi runner.
+    #[inline]
+    fn pi_runner(&self) -> &Arc<PiRunner> {
+        self.core.pi_runner()
     }
 
     /// Get the worktree manager.
@@ -525,6 +531,14 @@ impl App {
                         session.chat_view.push(
                             MessageDisplay::System {
                                 content: "Gemini CLI history import isn't supported yet, so previous messages won't be shown.".to_string(),
+                            }
+                            .to_chat_message(),
+                        );
+                    }
+                    AgentType::Pi => {
+                        session.chat_view.push(
+                            MessageDisplay::System {
+                                content: "Pi history import isn't supported yet, so previous messages won't be shown.".to_string(),
                             }
                             .to_chat_message(),
                         );
@@ -2058,6 +2072,7 @@ impl App {
                         AgentType::Codex => self.codex_runner().clone(),
                         AgentType::Gemini => self.gemini_runner().clone(),
                         AgentType::Opencode => self.opencode_runner().clone(),
+                        AgentType::Pi => self.pi_runner().clone(),
                     };
 
                     let event_tx = self.event_tx.clone();
@@ -3583,6 +3598,14 @@ impl App {
                                 .to_chat_message(),
                             );
                         }
+                        AgentType::Pi => {
+                            session.chat_view.push(
+                                MessageDisplay::System {
+                                    content: "Pi history import isn't supported yet, so previous messages won't be shown.".to_string(),
+                                }
+                                .to_chat_message(),
+                            );
+                        }
                         AgentType::Opencode => {
                             if let Ok((msgs, debug_entries, file_path)) =
                                 load_opencode_history_with_debug(session_id_str)
@@ -3690,6 +3713,7 @@ impl App {
             AgentType::Codex => crate::util::Tool::Codex,
             AgentType::Gemini => crate::util::Tool::Gemini,
             AgentType::Opencode => crate::util::Tool::Opencode,
+            AgentType::Pi => crate::util::Tool::Pi,
         }
     }
 
@@ -4955,6 +4979,16 @@ impl App {
                 session.chat_view.push(
                     MessageDisplay::System {
                         content: "Gemini CLI session import isn't supported yet.".to_string(),
+                    }
+                    .to_chat_message(),
+                );
+            }
+            AgentType::Pi => {
+                session.resume_session_id = None;
+                session.agent_session_id = None;
+                session.chat_view.push(
+                    MessageDisplay::System {
+                        content: "Pi session import isn't supported yet.".to_string(),
                     }
                     .to_chat_message(),
                 );

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -3730,7 +3730,10 @@ impl App {
     }
 
     fn reasoning_supported(agent_type: AgentType) -> bool {
-        matches!(agent_type, AgentType::Claude | AgentType::Codex)
+        matches!(
+            agent_type,
+            AgentType::Claude | AgentType::Codex | AgentType::Pi
+        )
     }
 
     fn session_started(session: &AgentSession) -> bool {
@@ -13285,6 +13288,37 @@ mod tests {
         app.state
             .reasoning_selector_state
             .show(AgentType::Codex, None);
+        app.state.reasoning_selector_state.insert_str("xhigh");
+        app.state.input_mode = InputMode::SelectingReasoning;
+
+        let mut effects = Vec::new();
+        app.handle_confirm_action(&mut effects).unwrap();
+
+        assert_eq!(app.state.input_mode, InputMode::Normal);
+        assert!(!app.state.reasoning_selector_state.is_visible());
+        assert!(effects.is_empty());
+
+        let session = app
+            .state
+            .tab_manager
+            .active_session()
+            .expect("session missing");
+        assert_eq!(session.reasoning_effort, Some(ReasoningEffort::XHigh));
+    }
+
+    #[test]
+    fn test_handle_confirm_action_selecting_reasoning_sets_pi_effort() {
+        let session_id = Uuid::new_v4();
+        let mut app = build_test_app_with_sessions(&[session_id]);
+        {
+            let session = app
+                .state
+                .tab_manager
+                .active_session_mut()
+                .expect("session missing");
+            session.agent_type = AgentType::Pi;
+        }
+        app.state.reasoning_selector_state.show(AgentType::Pi, None);
         app.state.reasoning_selector_state.insert_str("xhigh");
         app.state.input_mode = InputMode::SelectingReasoning;
 

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -9862,6 +9862,41 @@ impl App {
             return Ok(effects);
         }
 
+        if queued.len() == 1 && queued[0].mode == QueuedMessageMode::FollowUp {
+            let (text, images, placeholders) = app_queue::queued_to_submission(&queued[0]);
+            let is_active_tab = self.state.tab_manager.active_index() == tab_index;
+            let mut sent_pi_follow_up = false;
+            if let Some(session) = self.state.tab_manager.session_mut(tab_index) {
+                if session.agent_type == AgentType::Pi {
+                    if let Some(input_tx) = session.agent_input_tx.clone() {
+                        tokio::spawn(async move {
+                            if let Err(err) =
+                                input_tx.send(AgentInput::PiFollowUp { text, images }).await
+                            {
+                                tracing::warn!("Failed to send Pi follow-up: {}", err);
+                            }
+                        });
+                        session.start_processing();
+                        session.set_processing_state(ProcessingState::Thinking);
+                        if !placeholders.is_empty() {
+                            session.record_raw_event(
+                                EventDirection::Sent,
+                                "QueuedFollowUp",
+                                serde_json::json!({ "agent_type": "pi", "images": placeholders }),
+                            );
+                        }
+                        sent_pi_follow_up = true;
+                    }
+                }
+            }
+            if sent_pi_follow_up {
+                if is_active_tab {
+                    self.state.start_footer_spinner(None);
+                }
+                return Ok(effects);
+            }
+        }
+
         let (prompt, images, placeholders) =
             app_queue::build_queued_submission(&queued, queue_delivery);
         effects.extend(self.submit_prompt_for_tab(
@@ -11923,6 +11958,46 @@ mod tests {
         assert_eq!(concat, "First\n\nSecond");
         assert!(separate.contains("[Queued 1 of 2]"));
         assert!(separate.contains("[Queued 2 of 2]"));
+    }
+
+    #[tokio::test]
+    async fn test_drain_queue_for_tab_sends_pi_follow_up_input() {
+        let session_id = Uuid::new_v4();
+        let mut app = build_test_app_with_sessions(&[session_id]);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+
+        {
+            let session = app
+                .state
+                .tab_manager
+                .active_session_mut()
+                .expect("session missing");
+            session.agent_type = AgentType::Pi;
+            session.agent_input_tx = Some(tx);
+            session.is_processing = true;
+            session.queue_message(QueuedMessage {
+                id: Uuid::new_v4(),
+                mode: QueuedMessageMode::FollowUp,
+                text: "after this".to_string(),
+                images: Vec::new(),
+                created_at: Utc::now(),
+            });
+        }
+
+        let effects = app.drain_queue_for_tab(0).expect("drain should succeed");
+        assert!(effects.is_empty());
+
+        let input = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for Pi follow-up")
+            .expect("input channel closed");
+        assert!(matches!(
+            input,
+            AgentInput::PiFollowUp {
+                text,
+                images
+            } if text == "after this" && images.is_empty()
+        ));
     }
 
     #[test]

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -8117,7 +8117,11 @@ impl App {
         }
 
         // Start agent
-        if matches!(agent_type, AgentType::Gemini | AgentType::Opencode) && !images.is_empty() {
+        if matches!(
+            agent_type,
+            AgentType::Gemini | AgentType::Opencode | AgentType::Pi
+        ) && !images.is_empty()
+        {
             if let Some(session) = self.state.tab_manager.session_mut(tab_index) {
                 session.stop_processing();
                 session.pending_user_message = None;
@@ -8130,6 +8134,9 @@ impl App {
                         AgentType::Opencode => {
                             "Image attachments aren't supported for OpenCode in Conduit yet."
                                 .to_string()
+                        }
+                        AgentType::Pi => {
+                            "Image attachments aren't supported for Pi in Conduit yet.".to_string()
                         }
                         _ => "Image attachments aren't supported for this agent.".to_string(),
                     },
@@ -8240,7 +8247,10 @@ impl App {
             }
         }
 
-        if matches!(agent_type, AgentType::Codex | AgentType::Opencode) {
+        if matches!(
+            agent_type,
+            AgentType::Codex | AgentType::Opencode | AgentType::Pi
+        ) {
             let is_active_tab = self.state.tab_manager.active_index() == tab_index;
             if let Some(session) = self.state.tab_manager.session_mut(tab_index) {
                 if let Some(ref input_tx) = session.agent_input_tx {
@@ -12173,6 +12183,91 @@ mod tests {
         assert_eq!(*agent_type, AgentType::Codex);
         assert_eq!(config.resume_session.as_ref(), Some(&live_session));
         assert_eq!(config.prompt, "hi again");
+    }
+
+    #[tokio::test]
+    async fn test_submit_prompt_for_tab_uses_live_pi_input_channel() {
+        let session_id = Uuid::new_v4();
+        let mut app = build_test_app_with_sessions(&[session_id]);
+        let cwd = std::env::current_dir().expect("cwd");
+        let live_session = SessionId::from_string("/tmp/pi-session.jsonl");
+        let default_model = app.config().default_model_for(AgentType::Pi);
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+
+        {
+            let session = app
+                .state
+                .tab_manager
+                .session_by_id_mut(session_id)
+                .expect("session missing");
+            session.agent_type = AgentType::Pi;
+            session.model = Some(default_model);
+            session.model_invalid = false;
+            session.working_dir = Some(cwd);
+            session.agent_session_id = Some(live_session);
+            session.agent_input_tx = Some(tx);
+        }
+
+        let effects = app
+            .submit_prompt_for_tab(0, "hi from pi".to_string(), vec![], vec![], false, None)
+            .expect("submit should succeed");
+
+        assert!(
+            !effects
+                .iter()
+                .any(|effect| matches!(effect, Effect::StartAgent { .. })),
+            "live Pi sessions should reuse the existing input channel"
+        );
+
+        let input = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for pi input")
+            .expect("input channel closed");
+        match input {
+            AgentInput::CodexPrompt { text, .. } => assert_eq!(text, "hi from pi"),
+            other => panic!("unexpected input: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_submit_prompt_for_tab_resumes_saved_pi_session() {
+        let session_id = Uuid::new_v4();
+        let mut app = build_test_app_with_sessions(&[session_id]);
+        let cwd = std::env::current_dir().expect("cwd");
+        let saved_session = SessionId::from_string("/tmp/pi-history.jsonl");
+        let default_model = app.config().default_model_for(AgentType::Pi);
+
+        {
+            let session = app
+                .state
+                .tab_manager
+                .session_by_id_mut(session_id)
+                .expect("session missing");
+            session.agent_type = AgentType::Pi;
+            session.model = Some(default_model);
+            session.model_invalid = false;
+            session.working_dir = Some(cwd);
+            session.resume_session_id = Some(saved_session.clone());
+            session.agent_input_tx = None;
+        }
+
+        let effects = app
+            .submit_prompt_for_tab(0, "resume pi".to_string(), vec![], vec![], false, None)
+            .expect("submit should succeed");
+
+        let (agent_type, config) = effects
+            .iter()
+            .find_map(|effect| match effect {
+                Effect::StartAgent {
+                    agent_type, config, ..
+                } => Some((agent_type, config)),
+                _ => None,
+            })
+            .expect("expected StartAgent effect");
+
+        assert_eq!(*agent_type, AgentType::Pi);
+        assert_eq!(config.resume_session.as_ref(), Some(&saved_session));
+        assert_eq!(config.prompt, "resume pi");
     }
 
     #[test]

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -11333,7 +11333,10 @@ async fn generate_title_and_branch_impl(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::agent::events::{AssistantMessageEvent, ReasoningEvent, TurnCompletedEvent};
+    use crate::agent::events::{
+        AssistantMessageEvent, ReasoningEvent, ToolCompletedEvent, ToolStartedEvent,
+        TurnCompletedEvent,
+    };
     use crate::agent::{AgentType, ModelRegistry, ReasoningEffort, SessionId, TokenUsage};
     use crate::config::Config;
     use crate::data::{QueuedMessage, QueuedMessageMode};
@@ -12167,6 +12170,71 @@ mod tests {
             assert!(session.chat_view.streaming_buffer().is_none());
             assert!(session.chat_view.messages().is_empty());
         }
+    }
+
+    #[tokio::test]
+    async fn test_pi_tool_turn_keeps_final_assistant_reply_after_tool_output() {
+        let session_id = Uuid::new_v4();
+        let mut app = build_test_app_with_sessions(&[session_id]);
+
+        {
+            let session = app
+                .state
+                .tab_manager
+                .session_by_id_mut(session_id)
+                .expect("session missing");
+            session.set_agent_and_model(AgentType::Pi, Some("default".to_string()));
+            session.start_processing();
+        }
+
+        app.handle_agent_event(
+            session_id,
+            AgentEvent::ToolStarted(ToolStartedEvent {
+                tool_name: "bash".to_string(),
+                tool_id: "call-1".to_string(),
+                arguments: json!({ "command": "git status --short --branch" }),
+            }),
+        )
+        .await
+        .unwrap();
+
+        app.handle_agent_event(
+            session_id,
+            AgentEvent::ToolCompleted(ToolCompletedEvent {
+                tool_id: "call-1".to_string(),
+                success: true,
+                result: Some("## henrique/query-agent-identity".to_string()),
+                error: None,
+            }),
+        )
+        .await
+        .unwrap();
+
+        app.handle_agent_event(
+            session_id,
+            AgentEvent::AssistantMessage(AssistantMessageEvent {
+                text: "Yes — everything appears committed.".to_string(),
+                is_final: true,
+            }),
+        )
+        .await
+        .unwrap();
+
+        let session = app
+            .state
+            .tab_manager
+            .session_by_id_mut(session_id)
+            .expect("session missing");
+        let messages = session.chat_view.messages();
+
+        assert!(messages.iter().any(|msg| {
+            msg.role == MessageRole::Tool
+                && msg.content.contains("## henrique/query-agent-identity")
+        }));
+        assert!(messages.iter().any(|msg| {
+            msg.role == MessageRole::Assistant
+                && msg.content == "Yes — everything appears committed."
+        }));
     }
 
     #[tokio::test]

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -10068,6 +10068,7 @@ impl App {
                             let dialog = BaseDirDialog::new();
                             dialog.render(size, f.buffer_mut(), &self.state.base_dir_dialog_state);
                         } else if self.state.provider_selector_state.is_visible() {
+                            self.state.provider_selector_state.update_viewport(size);
                             let selector = ProviderSelector::new();
                             selector.render(
                                 size,
@@ -10507,6 +10508,7 @@ impl App {
         }
 
         if self.state.provider_selector_state.is_visible() {
+            self.state.provider_selector_state.update_viewport(size);
             let selector = ProviderSelector::new();
             selector.render(
                 size,

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -31,9 +31,9 @@ use crate::agent::events::UserQuestion;
 use crate::agent::{
     load_claude_history_with_debug, load_codex_history_with_debug,
     load_opencode_history_for_dir_with_debug, load_opencode_history_with_debug,
-    load_pi_history_with_debug, AgentEvent, AgentInput, AgentMode, AgentRunner, AgentStartConfig,
-    AgentType, ClaudeCodeRunner, CodexCliRunner, GeminiCliRunner, HistoryDebugEntry,
-    MessageDisplay, ModelRegistry, OpencodeRunner, PiRunner, SessionId,
+    load_pi_history_with_debug, load_pi_reasoning_effort, AgentEvent, AgentInput, AgentMode,
+    AgentRunner, AgentStartConfig, AgentType, ClaudeCodeRunner, CodexCliRunner, GeminiCliRunner,
+    HistoryDebugEntry, MessageDisplay, ModelRegistry, OpencodeRunner, PiRunner, SessionId,
 };
 use crate::command_resolver::{
     CommandResolver, ConduitCommand, MenuEntryKind, ResolveResult, ResolvedPrompt,
@@ -3617,6 +3617,8 @@ impl App {
                                     session.chat_view.push(msg);
                                 }
                             }
+                            session.reasoning_effort =
+                                load_pi_reasoning_effort(session_id_str).ok().flatten();
                         }
                         AgentType::Opencode => {
                             if let Ok((msgs, debug_entries, file_path)) =
@@ -5014,6 +5016,7 @@ impl App {
                         session.chat_view.push(msg);
                     }
                 }
+                session.reasoning_effort = load_pi_reasoning_effort(&session_ref).ok().flatten();
             }
             AgentType::Opencode => {
                 if let Ok((msgs, debug_entries, file_path)) =
@@ -12420,6 +12423,55 @@ mod tests {
         assert_eq!(*agent_type, AgentType::Pi);
         assert_eq!(config.images, vec![image_path]);
         assert_eq!(config.prompt, "describe image");
+    }
+
+    #[tokio::test]
+    async fn test_create_imported_session_tab_restores_pi_reasoning_effort() {
+        let mut app = build_test_app_with_sessions(&[]);
+        let temp = tempfile::TempDir::new().expect("tempdir");
+        let session_file = temp.path().join("pi-session.jsonl");
+        std::fs::write(
+            &session_file,
+            [
+                serde_json::json!({
+                    "type": "session",
+                    "version": 3,
+                    "id": "pi-session-id",
+                    "timestamp": "2026-04-02T10:00:00.000Z",
+                    "cwd": temp.path()
+                })
+                .to_string(),
+                serde_json::json!({
+                    "type": "message",
+                    "id": "a1",
+                    "parentId": null,
+                    "timestamp": "2026-04-02T10:00:01.000Z",
+                    "message": {"role": "user", "content": [{"type": "text", "text": "Hello"}]}
+                })
+                .to_string(),
+                serde_json::json!({
+                    "type": "thinking_level_change",
+                    "id": "a2",
+                    "parentId": "a1",
+                    "timestamp": "2026-04-02T10:00:02.000Z",
+                    "thinkingLevel": "high"
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        )
+        .expect("write session file");
+
+        app.create_imported_session_tab(AgentType::Pi, session_file, temp.path().to_path_buf())
+            .await
+            .expect("import should succeed");
+
+        let session = app
+            .state
+            .tab_manager
+            .active_session()
+            .expect("session missing");
+        assert_eq!(session.reasoning_effort, Some(ReasoningEffort::High));
     }
 
     #[test]

--- a/src/ui/app/app_actions_confirm.rs
+++ b/src/ui/app/app_actions_confirm.rs
@@ -1,4 +1,4 @@
-use crate::agent::MessageDisplay;
+use crate::agent::{AgentInput, AgentType, MessageDisplay};
 use crate::ui::app::App;
 use crate::ui::app_state::ModelPickerContext;
 use crate::ui::components::ConfirmationContext;
@@ -134,15 +134,46 @@ impl App {
                             return Ok(());
                         }
                         if App::session_started(session) {
-                            let display = MessageDisplay::Error {
-                                content: "Changing reasoning effort after a session has started is not supported. Start a new session/tab."
-                                    .to_string(),
-                            };
-                            session.chat_view.push(display.to_chat_message());
-                            return Ok(());
+                            if session.agent_type == AgentType::Pi {
+                                let Some(effort) = option.effort else {
+                                    let display = MessageDisplay::Error {
+                                        content: "Auto reasoning isn't available for active Pi sessions. Pick an explicit thinking level."
+                                            .to_string(),
+                                    };
+                                    session.chat_view.push(display.to_chat_message());
+                                    return Ok(());
+                                };
+                                let Some(input_tx) = session.agent_input_tx.clone() else {
+                                    let display = MessageDisplay::Error {
+                                        content: "Pi reasoning can't be changed because the live input channel is unavailable."
+                                            .to_string(),
+                                    };
+                                    session.chat_view.push(display.to_chat_message());
+                                    return Ok(());
+                                };
+                                tokio::spawn(async move {
+                                    if let Err(err) = input_tx
+                                        .send(AgentInput::PiSetThinkingLevel { level: effort })
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "Failed to send Pi thinking level update: {}",
+                                            err
+                                        );
+                                    }
+                                });
+                                session.set_reasoning_effort(Some(effort));
+                            } else {
+                                let display = MessageDisplay::Error {
+                                    content: "Changing reasoning effort after a session has started is not supported. Start a new session/tab."
+                                        .to_string(),
+                                };
+                                session.chat_view.push(display.to_chat_message());
+                                return Ok(());
+                            }
+                        } else {
+                            session.set_reasoning_effort(option.effort);
                         }
-
-                        session.set_reasoning_effort(option.effort);
                         let msg = match option.effort {
                             Some(effort) => {
                                 format!("Reasoning effort set to: {}", effort.display_name())

--- a/src/ui/capabilities.rs
+++ b/src/ui/capabilities.rs
@@ -16,12 +16,12 @@ impl AgentCapabilities {
     pub fn for_agent(agent_type: AgentType) -> Self {
         Self {
             supports_plan_mode: agent_type.supports_plan_mode(),
-            supports_interactive_input: false,
-            supports_steer: false,
-            supports_follow_up: false,
+            supports_interactive_input: matches!(agent_type, AgentType::Pi),
+            supports_steer: matches!(agent_type, AgentType::Pi),
+            supports_follow_up: matches!(agent_type, AgentType::Pi),
             supports_native_slash_commands: matches!(
                 agent_type,
-                AgentType::Claude | AgentType::Gemini | AgentType::Opencode
+                AgentType::Claude | AgentType::Gemini | AgentType::Opencode | AgentType::Pi
             ),
             supports_direct_user_skill_invocation: matches!(
                 agent_type,
@@ -33,5 +33,21 @@ impl AgentCapabilities {
             ),
             supports_command_template_expansion: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pi_capabilities_reflect_rpc_features() {
+        let capabilities = AgentCapabilities::for_agent(AgentType::Pi);
+
+        assert!(!capabilities.supports_plan_mode);
+        assert!(capabilities.supports_interactive_input);
+        assert!(capabilities.supports_steer);
+        assert!(capabilities.supports_follow_up);
+        assert!(capabilities.supports_native_slash_commands);
     }
 }

--- a/src/ui/components/agent_selector.rs
+++ b/src/ui/components/agent_selector.rs
@@ -63,6 +63,11 @@ impl AgentSelectorState {
                 name: "OpenCode",
                 description: "OpenCode multi-provider assistant",
             },
+            AgentType::Pi => AgentOption {
+                agent_type: AgentType::Pi,
+                name: "Pi",
+                description: "Pi coding harness",
+            },
         }
     }
 
@@ -72,6 +77,7 @@ impl AgentSelectorState {
             AgentType::Claude => Tool::Claude,
             AgentType::Gemini => Tool::Gemini,
             AgentType::Opencode => Tool::Opencode,
+            AgentType::Pi => Tool::Pi,
         }
     }
 

--- a/src/ui/components/model_selector.rs
+++ b/src/ui/components/model_selector.rs
@@ -128,6 +128,7 @@ impl ModelSelectorState {
                 AgentType::Codex => ModelRegistry::codex_models(),
                 AgentType::Gemini => ModelRegistry::gemini_models(),
                 AgentType::Opencode => ModelRegistry::opencode_models(),
+                AgentType::Pi => ModelRegistry::pi_models(),
             };
 
             if models.is_empty() {

--- a/src/ui/components/multi_select_dialog.rs
+++ b/src/ui/components/multi_select_dialog.rs
@@ -68,6 +68,20 @@ impl MultiSelectDialogState {
         self.update_filter();
     }
 
+    pub fn update_viewport(&mut self, area: Rect) {
+        let max_visible = MultiSelectDialog::list_area(area).height.max(1) as usize;
+        self.list.max_visible = max_visible;
+        self.list.clamp_selection();
+        if self.list.selected < self.list.scroll_offset {
+            self.list.scroll_offset = self.list.selected;
+        } else if self.list.selected >= self.list.scroll_offset + self.list.max_visible {
+            self.list.scroll_offset = self
+                .list
+                .selected
+                .saturating_sub(self.list.max_visible.saturating_sub(1));
+        }
+    }
+
     pub fn hide(&mut self) {
         self.visible = false;
     }

--- a/src/ui/components/provider_selector.rs
+++ b/src/ui/components/provider_selector.rs
@@ -3,6 +3,7 @@
 use crate::agent::AgentType;
 use crate::config::Config;
 use crate::util::{Tool, ToolAvailability};
+use ratatui::layout::Rect;
 
 use super::{MultiSelectDialog, MultiSelectDialogState, MultiSelectItem};
 
@@ -67,6 +68,10 @@ impl ProviderSelectorState {
 
     pub fn show(&mut self) {
         self.dialog.show();
+    }
+
+    pub fn update_viewport(&mut self, area: Rect) {
+        self.dialog.update_viewport(area);
     }
 
     pub fn hide(&mut self) {
@@ -153,3 +158,36 @@ impl Default for ProviderSelectorState {
 }
 
 pub type ProviderSelector = MultiSelectDialog;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_provider_dialog_scrolls_to_pi() {
+        let executable = std::env::current_exe().expect("test executable path");
+        let mut tools = ToolAvailability::default();
+        for tool in [
+            Tool::Claude,
+            Tool::Codex,
+            Tool::Gemini,
+            Tool::Opencode,
+            Tool::Pi,
+        ] {
+            assert!(tools.update_tool(tool, executable.clone()));
+        }
+
+        let mut state = ProviderSelectorState::configure_for(&Config::default(), &tools);
+        state.update_viewport(Rect::new(0, 0, 72, 12));
+
+        for _ in 0..4 {
+            state.select_next();
+        }
+
+        assert_eq!(
+            state.dialog.selected_item().map(|item| item.id.as_str()),
+            Some("pi")
+        );
+        assert_eq!(state.dialog.list.scroll_offset, 2);
+    }
+}

--- a/src/ui/components/provider_selector.rs
+++ b/src/ui/components/provider_selector.rs
@@ -18,8 +18,8 @@ impl ProviderSelectorState {
         }
     }
 
-    fn all_providers() -> [AgentType; 4] {
-        AgentType::preferred_order()
+    fn all_providers() -> Vec<AgentType> {
+        AgentType::preferred_order().to_vec()
     }
 
     fn provider_tool(provider: AgentType) -> Tool {
@@ -28,6 +28,7 @@ impl ProviderSelectorState {
             AgentType::Codex => Tool::Codex,
             AgentType::Gemini => Tool::Gemini,
             AgentType::Opencode => Tool::Opencode,
+            AgentType::Pi => Tool::Pi,
         }
     }
 

--- a/src/ui/components/reasoning_selector.rs
+++ b/src/ui/components/reasoning_selector.rs
@@ -184,6 +184,13 @@ impl ReasoningSelectorState {
                 });
             }
             AgentType::Codex | AgentType::Pi => {
+                if agent_type == AgentType::Pi {
+                    options.push(ReasoningOption {
+                        effort: Some(ReasoningEffort::Off),
+                        label: "Off",
+                        description: "Disable reasoning entirely",
+                    });
+                }
                 options.push(ReasoningOption {
                     effort: Some(ReasoningEffort::Minimal),
                     label: "Minimal",
@@ -387,7 +394,7 @@ impl ReasoningSelector {
         let hint = match state.agent_type {
             Some(AgentType::Claude) => "Claude supports: auto, low, medium, high",
             Some(AgentType::Codex) => "Codex supports: auto, minimal, low, medium, high, xhigh",
-            Some(AgentType::Pi) => "Pi supports: auto, minimal, low, medium, high, xhigh",
+            Some(AgentType::Pi) => "Pi supports: auto, off, minimal, low, medium, high, xhigh",
             Some(AgentType::Gemini) | Some(AgentType::Opencode) | None => {
                 "Reasoning effort is not available for this agent"
             }
@@ -418,6 +425,7 @@ mod tests {
             efforts,
             vec![
                 None,
+                Some(ReasoningEffort::Off),
                 Some(ReasoningEffort::Minimal),
                 Some(ReasoningEffort::Low),
                 Some(ReasoningEffort::Medium),

--- a/src/ui/components/reasoning_selector.rs
+++ b/src/ui/components/reasoning_selector.rs
@@ -210,7 +210,7 @@ impl ReasoningSelectorState {
                     description: "Maximum reasoning budget",
                 });
             }
-            AgentType::Gemini | AgentType::Opencode => {}
+            AgentType::Gemini | AgentType::Opencode | AgentType::Pi => {}
         }
         options
     }
@@ -387,7 +387,7 @@ impl ReasoningSelector {
         let hint = match state.agent_type {
             Some(AgentType::Claude) => "Claude supports: auto, low, medium, high",
             Some(AgentType::Codex) => "Codex supports: auto, minimal, low, medium, high, xhigh",
-            Some(AgentType::Gemini) | Some(AgentType::Opencode) | None => {
+            Some(AgentType::Gemini) | Some(AgentType::Opencode) | Some(AgentType::Pi) | None => {
                 "Reasoning effort is not available for this agent"
             }
         };

--- a/src/ui/components/reasoning_selector.rs
+++ b/src/ui/components/reasoning_selector.rs
@@ -183,7 +183,7 @@ impl ReasoningSelectorState {
                     description: "Best quality, slower and costlier",
                 });
             }
-            AgentType::Codex => {
+            AgentType::Codex | AgentType::Pi => {
                 options.push(ReasoningOption {
                     effort: Some(ReasoningEffort::Minimal),
                     label: "Minimal",
@@ -210,7 +210,7 @@ impl ReasoningSelectorState {
                     description: "Maximum reasoning budget",
                 });
             }
-            AgentType::Gemini | AgentType::Opencode | AgentType::Pi => {}
+            AgentType::Gemini | AgentType::Opencode => {}
         }
         options
     }
@@ -387,7 +387,8 @@ impl ReasoningSelector {
         let hint = match state.agent_type {
             Some(AgentType::Claude) => "Claude supports: auto, low, medium, high",
             Some(AgentType::Codex) => "Codex supports: auto, minimal, low, medium, high, xhigh",
-            Some(AgentType::Gemini) | Some(AgentType::Opencode) | Some(AgentType::Pi) | None => {
+            Some(AgentType::Pi) => "Pi supports: auto, minimal, low, medium, high, xhigh",
+            Some(AgentType::Gemini) | Some(AgentType::Opencode) | None => {
                 "Reasoning effort is not available for this agent"
             }
         };
@@ -400,5 +401,29 @@ impl ReasoningSelector {
 impl Default for ReasoningSelector {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pi_reasoning_options_include_full_thinking_range() {
+        let options = ReasoningSelectorState::build_options(AgentType::Pi);
+
+        let efforts: Vec<Option<ReasoningEffort>> =
+            options.iter().map(|option| option.effort).collect();
+        assert_eq!(
+            efforts,
+            vec![
+                None,
+                Some(ReasoningEffort::Minimal),
+                Some(ReasoningEffort::Low),
+                Some(ReasoningEffort::Medium),
+                Some(ReasoningEffort::High),
+                Some(ReasoningEffort::XHigh),
+            ]
+        );
     }
 }

--- a/src/ui/components/session_import_picker.rs
+++ b/src/ui/components/session_import_picker.rs
@@ -559,12 +559,14 @@ impl SessionImportPicker {
                 AgentType::Codex => "X",
                 AgentType::Gemini => "G",
                 AgentType::Opencode => "O",
+                AgentType::Pi => "P",
             };
             let agent_color = match session.agent_type {
                 AgentType::Claude => agent_claude(),
                 AgentType::Codex => agent_codex(),
                 AgentType::Gemini => agent_gemini(),
                 AgentType::Opencode => agent_opencode(),
+                AgentType::Pi => agent_opencode(),
             };
 
             // Calculate widths

--- a/src/ui/components/session_import_picker.rs
+++ b/src/ui/components/session_import_picker.rs
@@ -45,6 +45,8 @@ pub enum AgentFilter {
     Gemini,
     /// Show only OpenCode sessions
     Opencode,
+    /// Show only Pi sessions
+    Pi,
 }
 
 impl AgentFilter {
@@ -55,7 +57,8 @@ impl AgentFilter {
             AgentFilter::Claude => AgentFilter::Codex,
             AgentFilter::Codex => AgentFilter::Gemini,
             AgentFilter::Gemini => AgentFilter::Opencode,
-            AgentFilter::Opencode => AgentFilter::All,
+            AgentFilter::Opencode => AgentFilter::Pi,
+            AgentFilter::Pi => AgentFilter::All,
         }
     }
 
@@ -67,6 +70,7 @@ impl AgentFilter {
             AgentFilter::Codex => "Codex",
             AgentFilter::Gemini => "Gemini",
             AgentFilter::Opencode => "OpenCode",
+            AgentFilter::Pi => "Pi",
         }
     }
 }
@@ -203,6 +207,7 @@ impl SessionImportPickerState {
                     AgentFilter::Codex => matches!(s.agent_type, AgentType::Codex),
                     AgentFilter::Gemini => matches!(s.agent_type, AgentType::Gemini),
                     AgentFilter::Opencode => matches!(s.agent_type, AgentType::Opencode),
+                    AgentFilter::Pi => matches!(s.agent_type, AgentType::Pi),
                 }
             })
             .filter(|(_, s)| {
@@ -477,6 +482,7 @@ impl SessionImportPicker {
             AgentFilter::Codex,
             AgentFilter::Gemini,
             AgentFilter::Opencode,
+            AgentFilter::Pi,
         ] {
             let is_selected = state.agent_filter == filter;
             let label = format!(" {} ", filter.label());
@@ -488,6 +494,7 @@ impl SessionImportPicker {
                 AgentFilter::Codex => agent_codex(),
                 AgentFilter::Gemini => agent_gemini(),
                 AgentFilter::Opencode => agent_opencode(),
+                AgentFilter::Pi => agent_opencode(),
             };
             let style = if is_selected {
                 let fg = ensure_contrast_fg(base_fg, tab_selected_bg, 4.5);

--- a/src/util/tools.rs
+++ b/src/util/tools.rs
@@ -22,6 +22,8 @@ pub enum Tool {
     Gemini,
     /// OpenCode CLI agent
     Opencode,
+    /// Pi coding agent CLI
+    Pi,
 }
 
 impl Tool {
@@ -34,6 +36,7 @@ impl Tool {
             Tool::Codex => "codex",
             Tool::Gemini => "gemini",
             Tool::Opencode => "opencode",
+            Tool::Pi => "pi",
         }
     }
 
@@ -46,6 +49,7 @@ impl Tool {
             Tool::Codex => "Codex CLI",
             Tool::Gemini => "Gemini CLI",
             Tool::Opencode => "OpenCode",
+            Tool::Pi => "Pi",
         }
     }
 
@@ -58,6 +62,7 @@ impl Tool {
             Tool::Codex => "npm install -g @openai/codex\nhttps://github.com/openai/codex-cli",
             Tool::Gemini => "npm install -g @google/gemini-cli\nhttps://github.com/google-gemini/gemini-cli",
             Tool::Opencode => "brew install anomalyco/tap/opencode\nhttps://opencode.ai/docs",
+            Tool::Pi => "npm install -g @mariozechner/pi-coding-agent\nhttps://pi.dev",
         }
     }
 
@@ -70,6 +75,7 @@ impl Tool {
             Tool::Codex => "Codex is an AI coding assistant from OpenAI.",
             Tool::Gemini => "Gemini CLI is an AI coding assistant from Google.",
             Tool::Opencode => "OpenCode is a multi-provider AI coding assistant.",
+            Tool::Pi => "Pi is a minimal terminal coding harness.",
         }
     }
 
@@ -82,7 +88,7 @@ impl Tool {
     pub fn is_agent(&self) -> bool {
         matches!(
             self,
-            Tool::Claude | Tool::Codex | Tool::Gemini | Tool::Opencode
+            Tool::Claude | Tool::Codex | Tool::Gemini | Tool::Opencode | Tool::Pi
         )
     }
 
@@ -95,6 +101,7 @@ impl Tool {
             Tool::Codex,
             Tool::Gemini,
             Tool::Opencode,
+            Tool::Pi,
         ]
     }
 }
@@ -141,6 +148,7 @@ pub struct ToolPaths {
     pub codex: Option<PathBuf>,
     pub gemini: Option<PathBuf>,
     pub opencode: Option<PathBuf>,
+    pub pi: Option<PathBuf>,
 }
 
 impl ToolPaths {
@@ -153,6 +161,7 @@ impl ToolPaths {
             Tool::Codex => self.codex.as_ref(),
             Tool::Gemini => self.gemini.as_ref(),
             Tool::Opencode => self.opencode.as_ref(),
+            Tool::Pi => self.pi.as_ref(),
         }
     }
 
@@ -165,6 +174,7 @@ impl ToolPaths {
             Tool::Codex => self.codex = Some(path),
             Tool::Gemini => self.gemini = Some(path),
             Tool::Opencode => self.opencode = Some(path),
+            Tool::Pi => self.pi = Some(path),
         }
     }
 }
@@ -178,6 +188,7 @@ pub struct ToolAvailability {
     codex: ToolStatus,
     gemini: ToolStatus,
     opencode: ToolStatus,
+    pi: ToolStatus,
 }
 
 impl ToolAvailability {
@@ -195,6 +206,7 @@ impl ToolAvailability {
             codex: Self::detect_tool(Tool::Codex, configured_paths.codex.as_ref()),
             gemini: Self::detect_tool(Tool::Gemini, configured_paths.gemini.as_ref()),
             opencode: Self::detect_tool(Tool::Opencode, configured_paths.opencode.as_ref()),
+            pi: Self::detect_tool(Tool::Pi, configured_paths.pi.as_ref()),
         }
     }
 
@@ -258,6 +270,7 @@ impl ToolAvailability {
             Tool::Codex => &self.codex,
             Tool::Gemini => &self.gemini,
             Tool::Opencode => &self.opencode,
+            Tool::Pi => &self.pi,
         }
     }
 
@@ -294,6 +307,7 @@ impl ToolAvailability {
             || self.is_available(Tool::Codex)
             || self.is_available(Tool::Gemini)
             || self.is_available(Tool::Opencode)
+            || self.is_available(Tool::Pi)
     }
 
     /// Get list of available agents
@@ -324,6 +338,7 @@ impl ToolAvailability {
             Tool::Codex => self.codex = status,
             Tool::Gemini => self.gemini = status,
             Tool::Opencode => self.opencode = status,
+            Tool::Pi => self.pi = status,
         }
 
         is_available
@@ -369,6 +384,7 @@ mod tests {
         assert_eq!(Tool::Codex.binary_name(), "codex");
         assert_eq!(Tool::Gemini.binary_name(), "gemini");
         assert_eq!(Tool::Opencode.binary_name(), "opencode");
+        assert_eq!(Tool::Pi.binary_name(), "pi");
     }
 
     #[test]
@@ -379,6 +395,7 @@ mod tests {
         assert!(!Tool::Codex.is_required());
         assert!(!Tool::Gemini.is_required());
         assert!(!Tool::Opencode.is_required());
+        assert!(!Tool::Pi.is_required());
     }
 
     #[test]
@@ -389,6 +406,7 @@ mod tests {
         assert!(Tool::Codex.is_agent());
         assert!(Tool::Gemini.is_agent());
         assert!(Tool::Opencode.is_agent());
+        assert!(Tool::Pi.is_agent());
     }
 
     #[test]

--- a/src/web/handlers/external_sessions.rs
+++ b/src/web/handlers/external_sessions.rs
@@ -267,8 +267,9 @@ fn parse_agent_type(agent_type: &str) -> Result<AgentType, WebError> {
         "claude" => Ok(AgentType::Claude),
         "gemini" => Ok(AgentType::Gemini),
         "opencode" => Ok(AgentType::Opencode),
+        "pi" => Ok(AgentType::Pi),
         _ => Err(WebError::BadRequest(format!(
-            "Invalid agent type: {}. Must be one of: codex, claude, gemini, opencode",
+            "Invalid agent type: {}. Must be one of: codex, claude, gemini, opencode, pi",
             agent_type
         ))),
     }

--- a/src/web/handlers/models.rs
+++ b/src/web/handlers/models.rs
@@ -33,9 +33,10 @@ pub async fn set_default_model(
         "claude" => AgentType::Claude,
         "gemini" => AgentType::Gemini,
         "opencode" => AgentType::Opencode,
+        "pi" => AgentType::Pi,
         _ => {
             return Err(WebError::BadRequest(format!(
-                "Invalid agent type: {}. Must be one of: codex, claude, gemini, opencode",
+                "Invalid agent type: {}. Must be one of: codex, claude, gemini, opencode, pi",
                 payload.agent_type
             )));
         }

--- a/src/web/handlers/sessions.rs
+++ b/src/web/handlers/sessions.rs
@@ -122,9 +122,10 @@ pub async fn create_session(
         "claude" => AgentType::Claude,
         "gemini" => AgentType::Gemini,
         "opencode" => AgentType::Opencode,
+        "pi" => AgentType::Pi,
         _ => {
             return Err(WebError::BadRequest(format!(
-                "Invalid agent type: {}. Must be one of: codex, claude, gemini, opencode",
+                "Invalid agent type: {}. Must be one of: codex, claude, gemini, opencode, pi",
                 req.agent_type
             )));
         }
@@ -171,8 +172,9 @@ pub async fn update_session(
                 "claude" => Ok(AgentType::Claude),
                 "gemini" => Ok(AgentType::Gemini),
                 "opencode" => Ok(AgentType::Opencode),
+                "pi" => Ok(AgentType::Pi),
                 _ => Err(WebError::BadRequest(format!(
-                    "Invalid agent type: {}. Must be one of: codex, claude, gemini, opencode",
+                    "Invalid agent type: {}. Must be one of: codex, claude, gemini, opencode, pi",
                     agent_type_str
                 ))),
             },
@@ -239,6 +241,7 @@ fn load_history_for_session(session: &SessionTab) -> Vec<ChatMessage> {
                 tracing::warn!("Failed to load OpenCode history: {}", e);
                 Vec::new()
             }),
+        AgentType::Pi => Vec::new(),
     };
 
     if let Some(pending) = session.pending_user_message.as_ref() {
@@ -395,6 +398,10 @@ pub async fn get_session_events(
         },
         AgentType::Gemini => {
             // Gemini history loading not supported yet
+            vec![]
+        }
+        AgentType::Pi => {
+            // Pi history loading not supported yet
             vec![]
         }
         AgentType::Opencode => match load_opencode_history_with_debug(&agent_session_id) {

--- a/src/web/handlers/sessions.rs
+++ b/src/web/handlers/sessions.rs
@@ -10,7 +10,8 @@ use uuid::Uuid;
 
 use crate::agent::{
     load_claude_history_with_debug, load_codex_history_with_debug,
-    load_opencode_history_with_debug, AgentMode, AgentType, ModelRegistry,
+    load_opencode_history_with_debug, load_pi_history_with_debug, AgentMode, AgentType,
+    ModelRegistry,
 };
 use crate::core::resolve_repo_workspace_settings;
 use crate::core::services::session_service::CreateForkedSessionParams;
@@ -241,7 +242,12 @@ fn load_history_for_session(session: &SessionTab) -> Vec<ChatMessage> {
                 tracing::warn!("Failed to load OpenCode history: {}", e);
                 Vec::new()
             }),
-        AgentType::Pi => Vec::new(),
+        AgentType::Pi => load_pi_history_with_debug(agent_session_id)
+            .map(|(messages, _, _)| messages)
+            .unwrap_or_else(|e| {
+                tracing::warn!("Failed to load Pi history: {}", e);
+                Vec::new()
+            }),
     };
 
     if let Some(pending) = session.pending_user_message.as_ref() {
@@ -400,10 +406,17 @@ pub async fn get_session_events(
             // Gemini history loading not supported yet
             vec![]
         }
-        AgentType::Pi => {
-            // Pi history loading not supported yet
-            vec![]
-        }
+        AgentType::Pi => match load_pi_history_with_debug(&agent_session_id) {
+            Ok((msgs, entries, file_path)) => {
+                debug_entries = entries;
+                debug_file = Some(file_path.to_string_lossy().to_string());
+                msgs
+            }
+            Err(e) => {
+                tracing::warn!("Failed to load Pi history: {}", e);
+                vec![]
+            }
+        },
         AgentType::Opencode => match load_opencode_history_with_debug(&agent_session_id) {
             Ok((msgs, entries, file_path)) => {
                 debug_entries = entries;

--- a/src/web/handlers/settings.rs
+++ b/src/web/handlers/settings.rs
@@ -152,6 +152,7 @@ pub async fn get_providers(
                 AgentType::Codex => crate::util::Tool::Codex,
                 AgentType::Gemini => crate::util::Tool::Gemini,
                 AgentType::Opencode => crate::util::Tool::Opencode,
+                AgentType::Pi => crate::util::Tool::Pi,
             };
             ProviderInfo {
                 id: format!("{:?}", agent).to_lowercase(),
@@ -183,6 +184,7 @@ pub async fn set_providers(
             "claude" => Some(AgentType::Claude),
             "gemini" => Some(AgentType::Gemini),
             "opencode" => Some(AgentType::Opencode),
+            "pi" => Some(AgentType::Pi),
             _ => None,
         })
         .collect();

--- a/src/web/ws/handler.rs
+++ b/src/web/ws/handler.rs
@@ -15,7 +15,7 @@ use uuid::Uuid;
 use crate::agent::events::AgentEvent;
 use crate::agent::runner::{AgentInput, AgentRunner, AgentStartConfig, AgentType};
 use crate::agent::session::SessionId;
-use crate::agent::ReasoningEffort;
+use crate::agent::{PiFollowUpMode, ReasoningEffort};
 use crate::command_resolver::{CommandResolver, ConduitCommand, ResolveResult, SkillReference};
 use crate::core::services::{SessionService, UpdateSessionParams};
 use crate::core::ConduitCore;
@@ -517,6 +517,38 @@ impl SessionManager {
             })
             .await
             .map_err(|e| format!("Failed to send reasoning update: {}", e))?;
+
+        Ok(())
+    }
+
+    /// Update follow-up delivery mode for a running session.
+    pub async fn set_follow_up_mode(
+        &self,
+        session_id: Uuid,
+        follow_up_mode: PiFollowUpMode,
+    ) -> Result<(), String> {
+        let input_tx = {
+            let sessions = self.sessions.read().await;
+            let session = sessions
+                .get(&session_id)
+                .ok_or_else(|| format!("Session {} not found", session_id))?;
+            let input_tx = session.input_tx.clone().ok_or_else(|| {
+                "Session does not support live follow-up mode updates".to_string()
+            })?;
+            if session.agent_type != AgentType::Pi {
+                return Err(
+                    "Live follow-up mode updates are only supported for Pi sessions".to_string(),
+                );
+            }
+            input_tx
+        };
+
+        input_tx
+            .send(AgentInput::PiSetFollowUpMode {
+                mode: follow_up_mode,
+            })
+            .await
+            .map_err(|e| format!("Failed to send follow-up mode update: {}", e))?;
 
         Ok(())
     }
@@ -1619,6 +1651,45 @@ pub async fn handle_websocket(socket: WebSocket, session_manager: Arc<SessionMan
                 }
             }
 
+            ClientMessage::SetFollowUpMode {
+                session_id,
+                follow_up_mode,
+            } => {
+                let Some(follow_up_mode) = PiFollowUpMode::parse(&follow_up_mode) else {
+                    if let Err(send_err) = tx
+                        .send(ServerMessage::session_error(
+                            session_id,
+                            "Unsupported follow-up mode. Use one of: all, one-at-a-time.",
+                        ))
+                        .await
+                    {
+                        tracing::debug!(
+                            %session_id,
+                            error = ?send_err,
+                            "Failed to send session error"
+                        );
+                        break 'ws_loop;
+                    }
+                    continue;
+                };
+
+                if let Err(e) = session_manager
+                    .set_follow_up_mode(session_id, follow_up_mode)
+                    .await
+                {
+                    if let Err(send_err) =
+                        tx.send(ServerMessage::session_error(session_id, e)).await
+                    {
+                        tracing::debug!(
+                            %session_id,
+                            error = ?send_err,
+                            "Failed to send session error"
+                        );
+                        break 'ws_loop;
+                    }
+                }
+            }
+
             ClientMessage::StopSession { session_id } => {
                 // Clean up subscription first
                 {
@@ -1750,6 +1821,80 @@ mod tests {
 
         let error = session_manager
             .set_reasoning_effort(session_id, ReasoningEffort::High)
+            .await
+            .expect_err("non-Pi sessions should be rejected");
+        assert!(error.contains("only supported for Pi sessions"));
+    }
+
+    #[tokio::test]
+    async fn set_follow_up_mode_sends_live_pi_update() {
+        let core = Arc::new(RwLock::new(ConduitCore::new(
+            Config::default(),
+            ToolAvailability::default(),
+        )));
+        let session_manager = SessionManager::with_runner_overrides(core, HashMap::new());
+        let session_id = Uuid::new_v4();
+        let (input_tx, mut input_rx) = mpsc::channel(1);
+        let (event_tx, _) = broadcast::channel(1);
+
+        {
+            let mut sessions = session_manager.sessions.write().await;
+            sessions.insert(
+                session_id,
+                ActiveSession {
+                    agent_type: AgentType::Pi,
+                    working_dir: std::env::temp_dir(),
+                    pid: None,
+                    event_tx,
+                    input_tx: Some(input_tx),
+                },
+            );
+        }
+
+        session_manager
+            .set_follow_up_mode(session_id, PiFollowUpMode::OneAtATime)
+            .await
+            .expect("Pi follow-up mode update should succeed");
+
+        let input = tokio::time::timeout(std::time::Duration::from_secs(1), input_rx.recv())
+            .await
+            .expect("timed out waiting for follow-up mode update")
+            .expect("input channel closed");
+        assert!(matches!(
+            input,
+            AgentInput::PiSetFollowUpMode {
+                mode: PiFollowUpMode::OneAtATime
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn set_follow_up_mode_rejects_non_pi_sessions() {
+        let core = Arc::new(RwLock::new(ConduitCore::new(
+            Config::default(),
+            ToolAvailability::default(),
+        )));
+        let session_manager = SessionManager::with_runner_overrides(core, HashMap::new());
+        let session_id = Uuid::new_v4();
+        let (input_tx, _input_rx) = mpsc::channel(1);
+        let (event_tx, _) = broadcast::channel(1);
+
+        {
+            let mut sessions = session_manager.sessions.write().await;
+            sessions.insert(
+                session_id,
+                ActiveSession {
+                    agent_type: AgentType::Claude,
+                    working_dir: std::env::temp_dir(),
+                    pid: None,
+                    event_tx,
+                    input_tx: Some(input_tx),
+                },
+            );
+        }
+
+        let error = session_manager
+            .set_follow_up_mode(session_id, PiFollowUpMode::All)
             .await
             .expect_err("non-Pi sessions should be rejected");
         assert!(error.contains("only supported for Pi sessions"));

--- a/src/web/ws/handler.rs
+++ b/src/web/ws/handler.rs
@@ -1102,7 +1102,8 @@ pub async fn handle_websocket(socket: WebSocket, session_manager: Arc<SessionMan
                     Vec::new()
                 } else {
                     match agent_type {
-                        AgentType::Codex => match decode_image_attachments(&images) {
+                        AgentType::Codex | AgentType::Pi => match decode_image_attachments(&images)
+                        {
                             Ok(paths) => paths,
                             Err(error) => {
                                 if let Err(send_err) = tx
@@ -1164,23 +1165,6 @@ pub async fn handle_websocket(socket: WebSocket, session_manager: Arc<SessionMan
                                 .send(ServerMessage::session_error(
                                     session_id,
                                     "Image attachments are not supported for OpenCode sessions",
-                                ))
-                                .await
-                            {
-                                tracing::debug!(
-                                    %session_id,
-                                    error = ?send_err,
-                                    "Failed to send session error"
-                                );
-                                break 'ws_loop;
-                            }
-                            continue;
-                        }
-                        AgentType::Pi => {
-                            if let Err(send_err) = tx
-                                .send(ServerMessage::session_error(
-                                    session_id,
-                                    "Image attachments are not supported for Pi sessions",
                                 ))
                                 .await
                             {
@@ -1492,23 +1476,25 @@ pub async fn handle_websocket(socket: WebSocket, session_manager: Arc<SessionMan
                     Vec::new()
                 } else {
                     match agent_type {
-                        Some(AgentType::Codex) => match decode_image_attachments(&images) {
-                            Ok(paths) => paths,
-                            Err(error) => {
-                                if let Err(send_err) = tx
-                                    .send(ServerMessage::session_error(session_id, error))
-                                    .await
-                                {
-                                    tracing::debug!(
-                                        %session_id,
-                                        error = ?send_err,
-                                        "Failed to send session error"
-                                    );
-                                    break 'ws_loop;
+                        Some(AgentType::Codex) | Some(AgentType::Pi) => {
+                            match decode_image_attachments(&images) {
+                                Ok(paths) => paths,
+                                Err(error) => {
+                                    if let Err(send_err) = tx
+                                        .send(ServerMessage::session_error(session_id, error))
+                                        .await
+                                    {
+                                        tracing::debug!(
+                                            %session_id,
+                                            error = ?send_err,
+                                            "Failed to send session error"
+                                        );
+                                        break 'ws_loop;
+                                    }
+                                    continue;
                                 }
-                                continue;
                             }
-                        },
+                        }
                         Some(AgentType::Claude) => {
                             match build_claude_prompt_jsonl(&resolved_input_text, &images) {
                                 Ok(payload) => {
@@ -1553,23 +1539,6 @@ pub async fn handle_websocket(socket: WebSocket, session_manager: Arc<SessionMan
                                 .send(ServerMessage::session_error(
                                     session_id,
                                     "Image attachments are not supported for OpenCode sessions",
-                                ))
-                                .await
-                            {
-                                tracing::debug!(
-                                    %session_id,
-                                    error = ?send_err,
-                                    "Failed to send session error"
-                                );
-                                break 'ws_loop;
-                            }
-                            continue;
-                        }
-                        Some(AgentType::Pi) => {
-                            if let Err(send_err) = tx
-                                .send(ServerMessage::session_error(
-                                    session_id,
-                                    "Image attachments are not supported for Pi sessions",
                                 ))
                                 .await
                             {

--- a/src/web/ws/handler.rs
+++ b/src/web/ws/handler.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 use crate::agent::events::AgentEvent;
 use crate::agent::runner::{AgentInput, AgentRunner, AgentStartConfig, AgentType};
 use crate::agent::session::SessionId;
+use crate::agent::ReasoningEffort;
 use crate::command_resolver::{CommandResolver, ConduitCommand, ResolveResult, SkillReference};
 use crate::core::services::{SessionService, UpdateSessionParams};
 use crate::core::ConduitCore;
@@ -485,6 +486,37 @@ impl SessionManager {
             .send(agent_input)
             .await
             .map_err(|e| format!("Failed to send input: {}", e))?;
+
+        Ok(())
+    }
+
+    /// Update reasoning effort for a running session.
+    pub async fn set_reasoning_effort(
+        &self,
+        session_id: Uuid,
+        reasoning_effort: ReasoningEffort,
+    ) -> Result<(), String> {
+        let input_tx = {
+            let sessions = self.sessions.read().await;
+            let session = sessions
+                .get(&session_id)
+                .ok_or_else(|| format!("Session {} not found", session_id))?;
+            let input_tx = session
+                .input_tx
+                .clone()
+                .ok_or_else(|| "Session does not support live reasoning updates".to_string())?;
+            if session.agent_type != AgentType::Pi {
+                return Err("Live reasoning updates are only supported for Pi sessions".to_string());
+            }
+            input_tx
+        };
+
+        input_tx
+            .send(AgentInput::PiSetThinkingLevel {
+                level: reasoning_effort,
+            })
+            .await
+            .map_err(|e| format!("Failed to send reasoning update: {}", e))?;
 
         Ok(())
     }
@@ -1548,6 +1580,45 @@ pub async fn handle_websocket(socket: WebSocket, session_manager: Arc<SessionMan
                 }
             }
 
+            ClientMessage::SetReasoningEffort {
+                session_id,
+                reasoning_effort,
+            } => {
+                let Some(reasoning_effort) = ReasoningEffort::parse(&reasoning_effort) else {
+                    if let Err(send_err) = tx
+                        .send(ServerMessage::session_error(
+                            session_id,
+                            "Unsupported reasoning effort. Use one of: off, minimal, low, medium, high, xhigh.",
+                        ))
+                        .await
+                    {
+                        tracing::debug!(
+                            %session_id,
+                            error = ?send_err,
+                            "Failed to send session error"
+                        );
+                        break 'ws_loop;
+                    }
+                    continue;
+                };
+
+                if let Err(e) = session_manager
+                    .set_reasoning_effort(session_id, reasoning_effort)
+                    .await
+                {
+                    if let Err(send_err) =
+                        tx.send(ServerMessage::session_error(session_id, e)).await
+                    {
+                        tracing::debug!(
+                            %session_id,
+                            error = ?send_err,
+                            "Failed to send session error"
+                        );
+                        break 'ws_loop;
+                    }
+                }
+            }
+
             ClientMessage::StopSession { session_id } => {
                 // Clean up subscription first
                 {
@@ -1609,6 +1680,80 @@ mod tests {
     use crate::core::services::session_service::CreateImportedSessionParams;
     use crate::core::services::SessionService;
     use crate::util::ToolAvailability;
+
+    #[tokio::test]
+    async fn set_reasoning_effort_sends_live_pi_update() {
+        let core = Arc::new(RwLock::new(ConduitCore::new(
+            Config::default(),
+            ToolAvailability::default(),
+        )));
+        let session_manager = SessionManager::with_runner_overrides(core, HashMap::new());
+        let session_id = Uuid::new_v4();
+        let (input_tx, mut input_rx) = mpsc::channel(1);
+        let (event_tx, _) = broadcast::channel(1);
+
+        {
+            let mut sessions = session_manager.sessions.write().await;
+            sessions.insert(
+                session_id,
+                ActiveSession {
+                    agent_type: AgentType::Pi,
+                    working_dir: std::env::temp_dir(),
+                    pid: None,
+                    event_tx,
+                    input_tx: Some(input_tx),
+                },
+            );
+        }
+
+        session_manager
+            .set_reasoning_effort(session_id, ReasoningEffort::High)
+            .await
+            .expect("Pi reasoning update should succeed");
+
+        let input = tokio::time::timeout(std::time::Duration::from_secs(1), input_rx.recv())
+            .await
+            .expect("timed out waiting for reasoning update")
+            .expect("input channel closed");
+        assert!(matches!(
+            input,
+            AgentInput::PiSetThinkingLevel {
+                level: ReasoningEffort::High
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn set_reasoning_effort_rejects_non_pi_sessions() {
+        let core = Arc::new(RwLock::new(ConduitCore::new(
+            Config::default(),
+            ToolAvailability::default(),
+        )));
+        let session_manager = SessionManager::with_runner_overrides(core, HashMap::new());
+        let session_id = Uuid::new_v4();
+        let (input_tx, _input_rx) = mpsc::channel(1);
+        let (event_tx, _) = broadcast::channel(1);
+
+        {
+            let mut sessions = session_manager.sessions.write().await;
+            sessions.insert(
+                session_id,
+                ActiveSession {
+                    agent_type: AgentType::Claude,
+                    working_dir: std::env::temp_dir(),
+                    pid: None,
+                    event_tx,
+                    input_tx: Some(input_tx),
+                },
+            );
+        }
+
+        let error = session_manager
+            .set_reasoning_effort(session_id, ReasoningEffort::High)
+            .await
+            .expect_err("non-Pi sessions should be rejected");
+        assert!(error.contains("only supported for Pi sessions"));
+    }
 
     #[tokio::test]
     async fn start_session_resumes_saved_pi_session() {

--- a/src/web/ws/handler.rs
+++ b/src/web/ws/handler.rs
@@ -40,6 +40,7 @@ struct ActiveSession {
 pub struct SessionManager {
     sessions: Arc<RwLock<HashMap<Uuid, ActiveSession>>>,
     core: Arc<RwLock<ConduitCore>>,
+    runner_overrides: HashMap<AgentType, Arc<dyn AgentRunner>>,
 }
 
 struct StartSessionArgs {
@@ -132,7 +133,33 @@ impl SessionManager {
         Self {
             sessions: Arc::new(RwLock::new(HashMap::new())),
             core,
+            runner_overrides: HashMap::new(),
         }
+    }
+
+    #[cfg(test)]
+    fn with_runner_overrides(
+        core: Arc<RwLock<ConduitCore>>,
+        runner_overrides: HashMap<AgentType, Arc<dyn AgentRunner>>,
+    ) -> Self {
+        Self {
+            sessions: Arc::new(RwLock::new(HashMap::new())),
+            core,
+            runner_overrides,
+        }
+    }
+
+    fn runner_for(&self, core: &ConduitCore, agent_type: AgentType) -> Arc<dyn AgentRunner> {
+        self.runner_overrides
+            .get(&agent_type)
+            .cloned()
+            .unwrap_or_else(|| match agent_type {
+                AgentType::Claude => core.claude_runner().clone(),
+                AgentType::Codex => core.codex_runner().clone(),
+                AgentType::Gemini => core.gemini_runner().clone(),
+                AgentType::Opencode => core.opencode_runner().clone(),
+                AgentType::Pi => core.pi_runner().clone(),
+            })
     }
 
     /// Start a new agent session.
@@ -165,13 +192,7 @@ impl SessionManager {
 
         // Get the appropriate runner
         let core = self.core.read().await;
-        let runner: Arc<dyn AgentRunner> = match agent_type {
-            AgentType::Claude => core.claude_runner().clone(),
-            AgentType::Codex => core.codex_runner().clone(),
-            AgentType::Gemini => core.gemini_runner().clone(),
-            AgentType::Opencode => core.opencode_runner().clone(),
-            AgentType::Pi => core.pi_runner().clone(),
-        };
+        let runner = self.runner_for(&core, agent_type);
 
         if !runner.is_available() {
             return Err(format!("{} is not available", agent_type.display_name()));
@@ -196,7 +217,7 @@ impl SessionManager {
             config = config.with_skill(skill);
         }
 
-        if agent_type == AgentType::Opencode {
+        if matches!(agent_type, AgentType::Opencode | AgentType::Pi) {
             match SessionService::get_session(&core, session_id) {
                 Ok(session_tab) => {
                     if let Some(agent_session_id) = session_tab.agent_session_id {
@@ -206,8 +227,9 @@ impl SessionManager {
                 Err(error) => {
                     tracing::warn!(
                         %session_id,
+                        agent_type = %agent_type,
                         error = %error,
-                        "Failed to load session for OpenCode resume"
+                        "Failed to load session for agent resume"
                     );
                 }
             }
@@ -1699,4 +1721,66 @@ pub async fn handle_websocket(socket: WebSocket, session_manager: Arc<SessionMan
     }
 
     send_task.abort();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agent::MockAgentRunner;
+    use crate::config::Config;
+    use crate::core::services::session_service::CreateImportedSessionParams;
+    use crate::core::services::SessionService;
+    use crate::util::ToolAvailability;
+
+    #[tokio::test]
+    async fn start_session_resumes_saved_pi_session() {
+        let core = Arc::new(RwLock::new(ConduitCore::new(
+            Config::default(),
+            ToolAvailability::default(),
+        )));
+
+        let session = {
+            let core_read = core.read().await;
+            SessionService::create_imported_session(
+                &core_read,
+                CreateImportedSessionParams {
+                    workspace_id: None,
+                    agent_type: AgentType::Pi,
+                    agent_session_id: "/tmp/pi-session.jsonl".to_string(),
+                    title: Some("Imported Pi session".to_string()),
+                    model: Some("default".to_string()),
+                },
+            )
+            .expect("should create imported Pi session")
+        };
+
+        let pi_runner = Arc::new(MockAgentRunner::new(AgentType::Pi));
+        let session_manager = SessionManager::with_runner_overrides(
+            core,
+            HashMap::from([(AgentType::Pi, pi_runner.clone() as Arc<dyn AgentRunner>)]),
+        );
+
+        session_manager
+            .start_session(StartSessionArgs {
+                session_id: session.id,
+                agent_type: AgentType::Pi,
+                prompt: "continue".to_string(),
+                working_dir: std::env::temp_dir(),
+                model: Some("default".to_string()),
+                images: Vec::new(),
+                input_format: None,
+                stdin_payload: None,
+                skill: None,
+            })
+            .await
+            .expect("Pi session should start");
+
+        let config = pi_runner
+            .last_config()
+            .expect("mock runner captured config");
+        assert_eq!(
+            config.resume_session.as_ref().map(SessionId::as_str),
+            Some("/tmp/pi-session.jsonl")
+        );
+    }
 }

--- a/src/web/ws/handler.rs
+++ b/src/web/ws/handler.rs
@@ -752,6 +752,32 @@ fn decode_image_attachments(images: &[ImageAttachment]) -> Result<Vec<PathBuf>, 
     Ok(paths)
 }
 
+fn prepare_agent_images(
+    agent_type: Option<AgentType>,
+    prompt: &str,
+    images: &[ImageAttachment],
+) -> Result<(Vec<PathBuf>, Option<String>), String> {
+    if images.is_empty() {
+        return Ok((Vec::new(), None));
+    }
+
+    match agent_type {
+        Some(AgentType::Codex) | Some(AgentType::Pi) => {
+            decode_image_attachments(images).map(|paths| (paths, None))
+        }
+        Some(AgentType::Claude) => {
+            build_claude_prompt_jsonl(prompt, images).map(|payload| (Vec::new(), Some(payload)))
+        }
+        Some(AgentType::Gemini) => {
+            Err("Image attachments are not supported for Gemini sessions".to_string())
+        }
+        Some(AgentType::Opencode) => {
+            Err("Image attachments are not supported for OpenCode sessions".to_string())
+        }
+        None => Ok((Vec::new(), None)),
+    }
+}
+
 fn build_claude_prompt_jsonl(prompt: &str, images: &[ImageAttachment]) -> Result<String, String> {
     const SUPPORTED_MEDIA_TYPES: &[&str] = &[
         "image/png",
@@ -1098,85 +1124,27 @@ pub async fn handle_websocket(socket: WebSocket, session_manager: Arc<SessionMan
                 let mut stdin_payload: Option<String> = None;
                 let working_dir_path = PathBuf::from(working_dir);
 
-                let image_paths = if images.is_empty() {
-                    Vec::new()
-                } else {
-                    match agent_type {
-                        AgentType::Codex | AgentType::Pi => match decode_image_attachments(&images)
+                let image_paths = match prepare_agent_images(Some(agent_type), &prompt, &images) {
+                    Ok((paths, maybe_stdin_payload)) => {
+                        if let Some(payload) = maybe_stdin_payload {
+                            input_format = Some("stream-json".to_string());
+                            stdin_payload = Some(payload);
+                        }
+                        paths
+                    }
+                    Err(error) => {
+                        if let Err(send_err) = tx
+                            .send(ServerMessage::session_error(session_id, error))
+                            .await
                         {
-                            Ok(paths) => paths,
-                            Err(error) => {
-                                if let Err(send_err) = tx
-                                    .send(ServerMessage::session_error(session_id, error))
-                                    .await
-                                {
-                                    tracing::debug!(
-                                        %session_id,
-                                        error = ?send_err,
-                                        "Failed to send session error"
-                                    );
-                                    break 'ws_loop;
-                                }
-                                continue;
-                            }
-                        },
-                        AgentType::Claude => {
-                            match build_claude_prompt_jsonl(&prompt, &images) {
-                                Ok(payload) => {
-                                    input_format = Some("stream-json".to_string());
-                                    stdin_payload = Some(payload);
-                                }
-                                Err(error) => {
-                                    if let Err(send_err) = tx
-                                        .send(ServerMessage::session_error(session_id, error))
-                                        .await
-                                    {
-                                        tracing::debug!(
-                                            %session_id,
-                                            error = ?send_err,
-                                            "Failed to send session error"
-                                        );
-                                        break 'ws_loop;
-                                    }
-                                    continue;
-                                }
-                            }
-                            Vec::new()
+                            tracing::debug!(
+                                %session_id,
+                                error = ?send_err,
+                                "Failed to send session error"
+                            );
+                            break 'ws_loop;
                         }
-                        AgentType::Gemini => {
-                            if let Err(send_err) = tx
-                                .send(ServerMessage::session_error(
-                                    session_id,
-                                    "Image attachments are not supported for Gemini sessions",
-                                ))
-                                .await
-                            {
-                                tracing::debug!(
-                                    %session_id,
-                                    error = ?send_err,
-                                    "Failed to send session error"
-                                );
-                                break 'ws_loop;
-                            }
-                            continue;
-                        }
-                        AgentType::Opencode => {
-                            if let Err(send_err) = tx
-                                .send(ServerMessage::session_error(
-                                    session_id,
-                                    "Image attachments are not supported for OpenCode sessions",
-                                ))
-                                .await
-                            {
-                                tracing::debug!(
-                                    %session_id,
-                                    error = ?send_err,
-                                    "Failed to send session error"
-                                );
-                                break 'ws_loop;
-                            }
-                            continue;
-                        }
+                        continue;
                     }
                 };
 
@@ -1472,57 +1440,17 @@ pub async fn handle_websocket(socket: WebSocket, session_manager: Arc<SessionMan
                     ResolveResult::Passthrough { text } => (text.clone(), text, None),
                 };
                 let mut input_payload = input.clone();
-                let image_paths = if images.is_empty() {
-                    Vec::new()
-                } else {
-                    match agent_type {
-                        Some(AgentType::Codex) | Some(AgentType::Pi) => {
-                            match decode_image_attachments(&images) {
-                                Ok(paths) => paths,
-                                Err(error) => {
-                                    if let Err(send_err) = tx
-                                        .send(ServerMessage::session_error(session_id, error))
-                                        .await
-                                    {
-                                        tracing::debug!(
-                                            %session_id,
-                                            error = ?send_err,
-                                            "Failed to send session error"
-                                        );
-                                        break 'ws_loop;
-                                    }
-                                    continue;
-                                }
+                let image_paths =
+                    match prepare_agent_images(agent_type, &resolved_input_text, &images) {
+                        Ok((paths, maybe_payload)) => {
+                            if let Some(payload) = maybe_payload {
+                                input_payload = payload;
                             }
+                            paths
                         }
-                        Some(AgentType::Claude) => {
-                            match build_claude_prompt_jsonl(&resolved_input_text, &images) {
-                                Ok(payload) => {
-                                    input_payload = payload;
-                                    Vec::new()
-                                }
-                                Err(error) => {
-                                    if let Err(send_err) = tx
-                                        .send(ServerMessage::session_error(session_id, error))
-                                        .await
-                                    {
-                                        tracing::debug!(
-                                            %session_id,
-                                            error = ?send_err,
-                                            "Failed to send session error"
-                                        );
-                                        break 'ws_loop;
-                                    }
-                                    continue;
-                                }
-                            }
-                        }
-                        Some(AgentType::Gemini) => {
+                        Err(error) => {
                             if let Err(send_err) = tx
-                                .send(ServerMessage::session_error(
-                                    session_id,
-                                    "Image attachments are not supported for Gemini sessions",
-                                ))
+                                .send(ServerMessage::session_error(session_id, error))
                                 .await
                             {
                                 tracing::debug!(
@@ -1534,26 +1462,7 @@ pub async fn handle_websocket(socket: WebSocket, session_manager: Arc<SessionMan
                             }
                             continue;
                         }
-                        Some(AgentType::Opencode) => {
-                            if let Err(send_err) = tx
-                                .send(ServerMessage::session_error(
-                                    session_id,
-                                    "Image attachments are not supported for OpenCode sessions",
-                                ))
-                                .await
-                            {
-                                tracing::debug!(
-                                    %session_id,
-                                    error = ?send_err,
-                                    "Failed to send session error"
-                                );
-                                break 'ws_loop;
-                            }
-                            continue;
-                        }
-                        None => Vec::new(),
-                    }
-                };
+                    };
 
                 if matches!(agent_type, Some(AgentType::Claude)) && images.is_empty() {
                     match build_claude_prompt_jsonl(&resolved_input_text, &[]) {

--- a/src/web/ws/handler.rs
+++ b/src/web/ws/handler.rs
@@ -170,6 +170,7 @@ impl SessionManager {
             AgentType::Codex => core.codex_runner().clone(),
             AgentType::Gemini => core.gemini_runner().clone(),
             AgentType::Opencode => core.opencode_runner().clone(),
+            AgentType::Pi => core.pi_runner().clone(),
         };
 
         if !runner.is_available() {
@@ -448,12 +449,14 @@ impl SessionManager {
         // Send as appropriate input type based on agent
         let agent_input = match agent_type {
             AgentType::Claude => AgentInput::ClaudeJsonl(input),
-            AgentType::Codex | AgentType::Gemini | AgentType::Opencode => AgentInput::CodexPrompt {
-                text: input,
-                images,
-                model,
-                skill,
-            },
+            AgentType::Codex | AgentType::Gemini | AgentType::Opencode | AgentType::Pi => {
+                AgentInput::CodexPrompt {
+                    text: input,
+                    images,
+                    model,
+                    skill,
+                }
+            }
         };
 
         input_tx
@@ -1151,6 +1154,23 @@ pub async fn handle_websocket(socket: WebSocket, session_manager: Arc<SessionMan
                             }
                             continue;
                         }
+                        AgentType::Pi => {
+                            if let Err(send_err) = tx
+                                .send(ServerMessage::session_error(
+                                    session_id,
+                                    "Image attachments are not supported for Pi sessions",
+                                ))
+                                .await
+                            {
+                                tracing::debug!(
+                                    %session_id,
+                                    error = ?send_err,
+                                    "Failed to send session error"
+                                );
+                                break 'ws_loop;
+                            }
+                            continue;
+                        }
                     }
                 };
 
@@ -1511,6 +1531,23 @@ pub async fn handle_websocket(socket: WebSocket, session_manager: Arc<SessionMan
                                 .send(ServerMessage::session_error(
                                     session_id,
                                     "Image attachments are not supported for OpenCode sessions",
+                                ))
+                                .await
+                            {
+                                tracing::debug!(
+                                    %session_id,
+                                    error = ?send_err,
+                                    "Failed to send session error"
+                                );
+                                break 'ws_loop;
+                            }
+                            continue;
+                        }
+                        Some(AgentType::Pi) => {
+                            if let Err(send_err) = tx
+                                .send(ServerMessage::session_error(
+                                    session_id,
+                                    "Image attachments are not supported for Pi sessions",
                                 ))
                                 .await
                             {

--- a/src/web/ws/messages.rs
+++ b/src/web/ws/messages.rs
@@ -67,6 +67,12 @@ pub enum ClientMessage {
         response: serde_json::Value,
     },
 
+    /// Update reasoning effort for a running session.
+    SetReasoningEffort {
+        session_id: Uuid,
+        reasoning_effort: String,
+    },
+
     /// Stop a running agent session
     StopSession { session_id: Uuid },
 

--- a/src/web/ws/messages.rs
+++ b/src/web/ws/messages.rs
@@ -73,6 +73,12 @@ pub enum ClientMessage {
         reasoning_effort: String,
     },
 
+    /// Update follow-up delivery mode for a running Pi session.
+    SetFollowUpMode {
+        session_id: Uuid,
+        follow_up_mode: String,
+    },
+
     /// Stop a running agent session
     StopSession { session_id: Uuid },
 

--- a/src/web/ws/tests.rs
+++ b/src/web/ws/tests.rs
@@ -97,6 +97,30 @@ fn test_client_message_set_reasoning_effort_serialization() {
 }
 
 #[test]
+fn test_client_message_set_follow_up_mode_serialization() {
+    let session_id = Uuid::nil();
+    let msg = ClientMessage::SetFollowUpMode {
+        session_id,
+        follow_up_mode: "one-at-a-time".to_string(),
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    assert!(json.contains(r#""type":"set_follow_up_mode""#));
+    assert!(json.contains(r#""follow_up_mode":"one-at-a-time""#));
+
+    let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
+    if let ClientMessage::SetFollowUpMode {
+        session_id: parsed_id,
+        follow_up_mode,
+    } = parsed
+    {
+        assert_eq!(parsed_id, session_id);
+        assert_eq!(follow_up_mode, "one-at-a-time");
+    } else {
+        panic!("Expected SetFollowUpMode message");
+    }
+}
+
+#[test]
 fn test_server_message_pong_serialization() {
     let msg = ServerMessage::Pong;
     let json = serde_json::to_string(&msg).unwrap();

--- a/src/web/ws/tests.rs
+++ b/src/web/ws/tests.rs
@@ -3,6 +3,7 @@
 use super::messages::{ClientMessage, ServerMessage};
 use crate::agent::events::{AgentEvent, AssistantMessageEvent, SessionInitEvent};
 use crate::agent::session::SessionId;
+use crate::agent::ReasoningEffort;
 use uuid::Uuid;
 
 #[test]
@@ -68,6 +69,30 @@ fn test_client_message_start_session_serialization() {
         assert!(images.is_empty());
     } else {
         panic!("Expected StartSession message");
+    }
+}
+
+#[test]
+fn test_client_message_set_reasoning_effort_serialization() {
+    let session_id = Uuid::nil();
+    let msg = ClientMessage::SetReasoningEffort {
+        session_id,
+        reasoning_effort: ReasoningEffort::High.as_str().to_string(),
+    };
+    let json = serde_json::to_string(&msg).unwrap();
+    assert!(json.contains(r#""type":"set_reasoning_effort""#));
+    assert!(json.contains(r#""reasoning_effort":"high""#));
+
+    let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
+    if let ClientMessage::SetReasoningEffort {
+        session_id: parsed_id,
+        reasoning_effort,
+    } = parsed
+    {
+        assert_eq!(parsed_id, session_id);
+        assert_eq!(reasoning_effort, "high");
+    } else {
+        panic!("Expected SetReasoningEffort message");
     }
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -761,8 +761,8 @@ function AppContent() {
     updateSession.mutate({ id: activeSession.id, data: { agent_mode: nextMode } });
   };
 
-  const handleOpenModelPicker = () => {
-    window.dispatchEvent(new Event('conduit:open-model-picker'));
+  const handleOpenModelPicker = (mode: 'session' | 'default' = 'session') => {
+    window.dispatchEvent(new CustomEvent('conduit:open-model-picker', { detail: { mode } }));
   };
 
   const commands = useMemo<CommandPaletteItem[]>(
@@ -1108,7 +1108,7 @@ function AppContent() {
         isOpen={isSettingsOpen}
         onClose={() => setIsSettingsOpen(false)}
         onOpenBaseDirDialog={() => setIsBaseDirDialogOpen(true)}
-        onOpenModelPicker={handleOpenModelPicker}
+        onOpenModelPicker={() => handleOpenModelPicker('default')}
       />
       <ConfirmDialog
         isOpen={!!archiveWorkspaceTarget}

--- a/web/src/components/ChatInput.tsx
+++ b/web/src/components/ChatInput.tsx
@@ -1,6 +1,7 @@
 import { useRef, useEffect, useState, type KeyboardEvent } from 'react';
 import { Send, Loader2, GitBranch, ListPlus, ImagePlus, X, Square } from 'lucide-react';
 import { cn } from '../lib/cn';
+import { agentDisplayName } from '../lib/agentMetadata';
 import { ModeToggle } from './ModeToggle';
 
 interface ChatInputProps {
@@ -21,7 +22,7 @@ interface ChatInputProps {
   notice?: string | null;
   // Session/workspace info for status line
   modelDisplayName?: string | null;
-  agentType?: 'claude' | 'codex' | 'gemini' | 'opencode' | null;
+  agentType?: 'claude' | 'codex' | 'gemini' | 'opencode' | 'pi' | null;
   agentMode?: string | null;
   gitStats?: { additions: number; deletions: number } | null;
   branch?: string | null;
@@ -416,13 +417,7 @@ export function ChatInput({
           )}
           {agentType && (
             <span className="shrink-0">
-              {agentType === 'claude'
-                ? 'Claude Code'
-                : agentType === 'codex'
-                  ? 'Codex CLI'
-                  : agentType === 'opencode'
-                    ? 'OpenCode'
-                    : 'Gemini CLI'}
+              {agentDisplayName(agentType)}
             </span>
           )}
           {!modelDisplayName && !agentType && !canChangeModel && (

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -25,6 +25,7 @@ import {
 } from '../hooks';
 import { getFileContent, getSessionEventsPage } from '../lib/api';
 import { supportsPlanMode } from '../lib/agentCapabilities';
+import { agentAccentColor, agentDisplayName } from '../lib/agentMetadata';
 import type {
   Session,
   UserQuestion,
@@ -1184,10 +1185,10 @@ export function ChatView({
   const currentAttachments = session ? attachmentsBySession[session.id] ?? [] : [];
   const canStop = isProcessing || isAwaitingResponse;
 
-  const handleModelSelect = useCallback((modelId: string, newAgentType: 'claude' | 'codex' | 'gemini' | 'opencode') => {
+  const handleModelSelect = useCallback((modelId: string, newAgentType: 'claude' | 'codex' | 'gemini' | 'opencode' | 'pi') => {
     if (!session) return;
     // Only include agent_type in the request if it's different from current
-    const data: { model: string; agent_type?: 'claude' | 'codex' | 'gemini' | 'opencode' } = { model: modelId };
+    const data: { model: string; agent_type?: 'claude' | 'codex' | 'gemini' | 'opencode' | 'pi' } = { model: modelId };
     if (newAgentType !== session.agent_type) {
       data.agent_type = newAgentType;
     }
@@ -1206,7 +1207,7 @@ export function ChatView({
   }, [session, updateSessionMutation, onNotify]);
 
   const handleSetDefaultModel = useCallback(
-    (modelId: string, newAgentType: 'claude' | 'codex' | 'gemini' | 'opencode') => {
+    (modelId: string, newAgentType: 'claude' | 'codex' | 'gemini' | 'opencode' | 'pi') => {
       setDefaultModelMutation.mutate({ agent_type: newAgentType, model_id: modelId });
     },
     [setDefaultModelMutation]
@@ -1287,16 +1288,7 @@ export function ChatView({
       <div className="flex shrink-0 items-center justify-between border-b border-border px-4 py-3">
         <div className="flex items-center gap-3">
           <span
-            className={cn(
-              'h-3 w-3 rounded-full',
-              session.agent_type === 'claude'
-                ? 'bg-orange-400'
-                : session.agent_type === 'codex'
-                ? 'bg-green-400'
-                : session.agent_type === 'opencode'
-                ? 'bg-teal-400'
-                : 'bg-blue-400'
-            )}
+            className={cn('h-3 w-3 rounded-full', agentAccentColor(session.agent_type))}
           />
           <div>
             <h3 className="font-medium text-text">
@@ -1306,13 +1298,7 @@ export function ChatView({
               {session.model && <span>{session.model}</span>}
               {session.model && ' · '}
               <span className="capitalize">
-                {session.agent_type === 'claude'
-                  ? 'Claude Code'
-                  : session.agent_type === 'codex'
-                  ? 'Codex CLI'
-                  : session.agent_type === 'opencode'
-                  ? 'OpenCode'
-                  : 'Gemini CLI'}
+                {agentDisplayName(session.agent_type)}
             </span>
             </p>
           </div>

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -38,6 +38,8 @@ import type {
 import { MessageSquarePlus, Loader2, Bug, GitBranch, GitPullRequest } from 'lucide-react';
 import { cn } from '../lib/cn';
 
+type ModelPickerMode = 'session' | 'default';
+
 interface ChatViewProps {
   session: Session | null;
   onNewSession?: () => void;
@@ -232,6 +234,7 @@ export function ChatView({
   const [pendingControlResponse, setPendingControlResponse] = useState<unknown | null>(null);
   const [showRawEvents, setShowRawEvents] = useState(false);
   const [showModelSelector, setShowModelSelector] = useState(false);
+  const [modelPickerMode, setModelPickerMode] = useState<ModelPickerMode>('session');
   const [escHint, setEscHint] = useState<string | null>(null);
   const [drafts, setDrafts] = useState<Record<string, string>>({});
   const [optimisticMessages, setOptimisticMessages] = useState<Record<string, string[]>>({});
@@ -1150,15 +1153,21 @@ export function ChatView({
     supportsPlanMode(session?.agent_type) && !session?.agent_session_id && !isProcessing;
 
   useEffect(() => {
-    const handleOpenModelPicker = () => {
+    const handleOpenModelPicker = (event?: Event) => {
       if (!session) {
         onNotify?.('No active session.', 'error');
         return;
       }
-      if (!canChangeModel) {
+
+      const pickerMode =
+        event instanceof CustomEvent && event.detail?.mode === 'default' ? 'default' : 'session';
+
+      if (pickerMode === 'session' && !canChangeModel) {
         onNotify?.('Wait for the current response to finish before changing the model.', 'error');
         return;
       }
+
+      setModelPickerMode(pickerMode);
       setShowModelSelector(true);
     };
 
@@ -1187,7 +1196,20 @@ export function ChatView({
 
   const handleModelSelect = useCallback((modelId: string, newAgentType: 'claude' | 'codex' | 'gemini' | 'opencode' | 'pi') => {
     if (!session) return;
-    // Only include agent_type in the request if it's different from current
+
+    if (modelPickerMode === 'default') {
+      setDefaultModelMutation.mutate(
+        { agent_type: newAgentType, model_id: modelId },
+        {
+          onSuccess: () => {
+            setShowModelSelector(false);
+            setModelPickerMode('session');
+          },
+        }
+      );
+      return;
+    }
+
     const data: { model: string; agent_type?: 'claude' | 'codex' | 'gemini' | 'opencode' | 'pi' } = { model: modelId };
     if (newAgentType !== session.agent_type) {
       data.agent_type = newAgentType;
@@ -1204,7 +1226,7 @@ export function ChatView({
         },
       }
     );
-  }, [session, updateSessionMutation, onNotify]);
+  }, [modelPickerMode, onNotify, session, setDefaultModelMutation, updateSessionMutation]);
 
   const handleSetDefaultModel = useCallback(
     (modelId: string, newAgentType: 'claude' | 'codex' | 'gemini' | 'opencode' | 'pi') => {
@@ -1448,7 +1470,10 @@ export function ChatView({
         agentMode={supportsPlanMode(session?.agent_type) ? effectiveAgentMode : undefined}
         gitStats={status?.git_stats}
         branch={workspace?.branch}
-        onModelClick={() => setShowModelSelector(true)}
+        onModelClick={() => {
+          setModelPickerMode('session');
+          setShowModelSelector(true);
+        }}
         canChangeModel={canChangeModel}
         onModeToggle={supportsPlanMode(session?.agent_type) ? handleToggleAgentMode : undefined}
         canChangeMode={canChangeMode}
@@ -1464,13 +1489,18 @@ export function ChatView({
       {/* Model selector dialog */}
       <ModelSelectorDialog
         isOpen={showModelSelector}
-        onClose={() => setShowModelSelector(false)}
+        onClose={() => {
+          setShowModelSelector(false);
+          setModelPickerMode('session');
+        }}
         currentModel={session?.model ?? null}
         agentType={session?.agent_type ?? 'claude'}
         onSelect={handleModelSelect}
         onSetDefault={handleSetDefaultModel}
         isUpdating={updateSessionMutation.isPending}
         isSettingDefault={setDefaultModelMutation.isPending}
+        title={modelPickerMode === 'default' ? 'Default Model' : 'Select Model'}
+        primaryActionLabel={modelPickerMode === 'default' ? 'Set Default' : 'Select Model'}
       />
     </div>
   );

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -2,6 +2,7 @@ import { useHealth } from '../hooks';
 import { Circle, Settings, PanelLeft, GitBranch, GitPullRequest, Activity, Download } from 'lucide-react';
 import { cn } from '../lib/cn';
 import { supportsPlanMode } from '../lib/agentCapabilities';
+import { agentAccentColor, agentDisplayName } from '../lib/agentMetadata';
 import { ThemeSwitcher } from './ThemeSwitcher';
 import type { Session, Workspace, WorkspaceStatus } from '../types';
 
@@ -54,26 +55,9 @@ export function Header({
         {activeSession && (
           <div className="flex items-center gap-2 rounded-full bg-surface-elevated px-2.5 py-1 text-xs text-text">
             <span
-              className={cn(
-                'h-2 w-2 rounded-full',
-                activeSession.agent_type === 'claude'
-                  ? 'bg-orange-400'
-                  : activeSession.agent_type === 'codex'
-                  ? 'bg-green-400'
-                  : activeSession.agent_type === 'opencode'
-                  ? 'bg-teal-400'
-                  : 'bg-blue-400'
-              )}
+              className={cn('h-2 w-2 rounded-full', agentAccentColor(activeSession.agent_type))}
             />
-            <span className="capitalize">
-              {activeSession.agent_type === 'claude'
-                ? 'Claude'
-                : activeSession.agent_type === 'codex'
-                ? 'Codex'
-                : activeSession.agent_type === 'opencode'
-                ? 'OpenCode'
-                : 'Gemini'}
-            </span>
+            <span>{agentDisplayName(activeSession.agent_type, { short: true })}</span>
             {supportsPlanMode(activeSession.agent_type) && (
               <span className="text-text-muted">
                 · {effectiveAgentMode === 'plan' ? 'Plan' : 'Build'}

--- a/web/src/components/ModelSelectorDialog.tsx
+++ b/web/src/components/ModelSelectorDialog.tsx
@@ -1,16 +1,16 @@
 import { useEffect, useRef, useState, useMemo } from 'react';
 import { X, Loader2, Search, Check } from 'lucide-react';
 import { useModels } from '../hooks';
-import type { ModelInfo } from '../types';
+import type { AgentType, ModelInfo } from '../types';
 import { cn } from '../lib/cn';
 
 interface ModelSelectorDialogProps {
   isOpen: boolean;
   onClose: () => void;
   currentModel: string | null;
-  agentType: 'claude' | 'codex' | 'gemini' | 'opencode';
-  onSelect: (modelId: string, newAgentType: 'claude' | 'codex' | 'gemini' | 'opencode') => void;
-  onSetDefault: (modelId: string, newAgentType: 'claude' | 'codex' | 'gemini' | 'opencode') => void;
+  agentType: AgentType;
+  onSelect: (modelId: string, newAgentType: AgentType) => void;
+  onSetDefault: (modelId: string, newAgentType: AgentType) => void;
   isUpdating?: boolean;
   isSettingDefault?: boolean;
 }
@@ -56,10 +56,10 @@ export function ModelSelectorDialog({
 
   // Flatten models for keyboard navigation
   const flatModels = useMemo(() => {
-    const models: { model: ModelInfo; groupAgentType: 'claude' | 'codex' | 'gemini' | 'opencode' }[] = [];
+    const models: { model: ModelInfo; groupAgentType: AgentType }[] = [];
     filteredGroups.forEach((group) => {
       group.models.forEach((model) => {
-        models.push({ model, groupAgentType: group.agent_type as 'claude' | 'codex' | 'gemini' | 'opencode' });
+        models.push({ model, groupAgentType: group.agent_type as AgentType });
       });
     });
     return models;
@@ -118,12 +118,12 @@ export function ModelSelectorDialog({
     }
   };
 
-  const handleSelect = (modelId: string, modelAgentType: 'claude' | 'codex' | 'gemini' | 'opencode') => {
+  const handleSelect = (modelId: string, modelAgentType: AgentType) => {
     if (isBusy) return;
     onSelect(modelId, modelAgentType);
   };
 
-  const handleSetDefault = (modelId: string, modelAgentType: 'claude' | 'codex' | 'gemini' | 'opencode') => {
+  const handleSetDefault = (modelId: string, modelAgentType: AgentType) => {
     if (isBusy) return;
     onSetDefault(modelId, modelAgentType);
   };
@@ -197,7 +197,7 @@ export function ModelSelectorDialog({
                     const isSelected = model.id === currentModel && model.agent_type === agentType;
                     const isHighlighted = currentFlatIndex === selectedIndex;
                     const flatIndex = currentFlatIndex;
-                    const groupAgentType = group.agent_type as 'claude' | 'codex' | 'gemini' | 'opencode';
+                    const groupAgentType = group.agent_type as AgentType;
                     currentFlatIndex++;
 
                     return (

--- a/web/src/components/ModelSelectorDialog.tsx
+++ b/web/src/components/ModelSelectorDialog.tsx
@@ -13,6 +13,8 @@ interface ModelSelectorDialogProps {
   onSetDefault: (modelId: string, newAgentType: AgentType) => void;
   isUpdating?: boolean;
   isSettingDefault?: boolean;
+  title?: string;
+  primaryActionLabel?: string;
 }
 
 export function ModelSelectorDialog({
@@ -24,6 +26,8 @@ export function ModelSelectorDialog({
   onSetDefault,
   isUpdating = false,
   isSettingDefault = false,
+  title = 'Select Model',
+  primaryActionLabel = 'Select Model',
 }: ModelSelectorDialogProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -147,7 +151,7 @@ export function ModelSelectorDialog({
       <div className="flex max-h-[600px] flex-col">
         {/* Header */}
         <div className="flex shrink-0 items-center justify-between border-b border-border px-6 py-4">
-          <h2 className="text-lg font-semibold text-text">Select Model</h2>
+          <h2 className="text-lg font-semibold text-text">{title}</h2>
           <button
             onClick={onClose}
             disabled={isBusy}
@@ -282,7 +286,7 @@ export function ModelSelectorDialog({
             )}
           >
             {isBusy && <Loader2 className="h-4 w-4 animate-spin" />}
-            {isUpdating ? 'Updating...' : 'Select Model'}
+            {isUpdating ? 'Updating...' : primaryActionLabel}
           </button>
         </div>
       </div>

--- a/web/src/components/SessionImportDialog.tsx
+++ b/web/src/components/SessionImportDialog.tsx
@@ -4,7 +4,7 @@ import { useExternalSessions, useImportExternalSession } from '../hooks';
 import type { ExternalSession, Session } from '../types';
 import { cn } from '../lib/cn';
 
-type AgentFilter = 'all' | 'claude' | 'codex' | 'gemini' | 'opencode';
+type AgentFilter = 'all' | 'claude' | 'codex' | 'gemini' | 'opencode' | 'pi';
 
 interface SessionImportDialogProps {
   isOpen: boolean;
@@ -18,6 +18,7 @@ const FILTER_LABELS: Record<AgentFilter, string> = {
   codex: 'Codex',
   gemini: 'Gemini',
   opencode: 'OpenCode',
+  pi: 'Pi',
 };
 
 export function SessionImportDialog({ isOpen, onClose, onImported }: SessionImportDialogProps) {

--- a/web/src/components/SessionTabs.tsx
+++ b/web/src/components/SessionTabs.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { X, FileText, Loader2 } from 'lucide-react';
 import { cn } from '../lib/cn';
+import { agentAccentColor } from '../lib/agentMetadata';
 import { useProcessingSessions, useUnseenSessions } from '../hooks';
 import type { Session, Workspace, FileViewerTab } from '../types';
 
@@ -125,16 +126,7 @@ export function SessionTabs({
           // Default: agent type indicator
           return (
             <span
-              className={cn(
-                'h-2 w-2 rounded-full',
-                session.agent_type === 'claude'
-                  ? 'bg-orange-400'
-                  : session.agent_type === 'codex'
-                  ? 'bg-green-400'
-                  : session.agent_type === 'opencode'
-                  ? 'bg-teal-400'
-                  : 'bg-blue-400'
-              )}
+              className={cn('h-2 w-2 rounded-full', agentAccentColor(session.agent_type))}
             />
           );
         };

--- a/web/src/lib/agentMetadata.ts
+++ b/web/src/lib/agentMetadata.ts
@@ -1,0 +1,33 @@
+import type { AgentType } from '../types';
+
+export function agentDisplayName(agentType: AgentType, options?: { short?: boolean }): string {
+  const short = options?.short ?? false;
+
+  switch (agentType) {
+    case 'claude':
+      return short ? 'Claude' : 'Claude Code';
+    case 'codex':
+      return short ? 'Codex' : 'Codex CLI';
+    case 'gemini':
+      return short ? 'Gemini' : 'Gemini CLI';
+    case 'opencode':
+      return 'OpenCode';
+    case 'pi':
+      return 'Pi';
+  }
+}
+
+export function agentAccentColor(agentType: AgentType): string {
+  switch (agentType) {
+    case 'claude':
+      return 'bg-orange-400';
+    case 'codex':
+      return 'bg-green-400';
+    case 'opencode':
+      return 'bg-teal-400';
+    case 'gemini':
+      return 'bg-blue-400';
+    case 'pi':
+      return 'bg-indigo-400';
+  }
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1,6 +1,7 @@
 // API types matching Rust backend
 
 export type WorkspaceMode = 'worktree' | 'checkout';
+export type AgentType = 'claude' | 'codex' | 'gemini' | 'opencode' | 'pi';
 
 export interface Repository {
   id: string;
@@ -57,7 +58,7 @@ export interface Session {
   id: string;
   tab_index: number;
   workspace_id: string | null;
-  agent_type: 'claude' | 'codex' | 'gemini' | 'opencode';
+  agent_type: AgentType;
   agent_mode: string | null;
   agent_session_id: string | null;
   model: string | null;
@@ -120,7 +121,7 @@ export interface ArchiveWorkspaceRequest {
 
 export interface CreateSessionRequest {
   workspace_id?: string;
-  agent_type: 'claude' | 'codex' | 'gemini' | 'opencode';
+  agent_type: AgentType;
   model?: string;
 }
 
@@ -176,7 +177,7 @@ export interface BootstrapResponse {
 
 export interface ExternalSession {
   id: string;
-  agent_type: 'claude' | 'codex' | 'gemini' | 'opencode';
+  agent_type: AgentType;
   display: string;
   project?: string | null;
   project_name?: string | null;
@@ -313,7 +314,7 @@ export interface ModelInfo {
   display_name: string;
   description: string;
   is_default: boolean;
-  agent_type: 'claude' | 'codex' | 'gemini' | 'opencode';
+  agent_type: AgentType;
   context_window: number;
 }
 
@@ -330,12 +331,12 @@ export interface ListModelsResponse {
 
 export interface UpdateSessionRequest {
   model?: string;
-  agent_type?: 'claude' | 'codex' | 'gemini' | 'opencode';
+  agent_type?: AgentType;
   agent_mode?: 'build' | 'plan';
 }
 
 export interface SetDefaultModelRequest {
-  agent_type: 'claude' | 'codex' | 'gemini' | 'opencode';
+  agent_type: AgentType;
   model_id: string;
 }
 

--- a/web/tests/e2e/fixtures.ts
+++ b/web/tests/e2e/fixtures.ts
@@ -1,5 +1,5 @@
 import type { Page, Route } from '@playwright/test';
-import type { QueuedMessage, Session, UiState } from '../../src/types';
+import type { ListModelsResponse, QueuedMessage, Session, UiState } from '../../src/types';
 
 export const sessionId = 'session-1';
 export const workspaceId = 'workspace-1';
@@ -314,6 +314,61 @@ export const sessionEventsResponse = {
   debug_entries: debugEntries,
 };
 
+export const settingsResponse = {
+  items: [
+    {
+      id: 'projects_directory',
+      title: 'Projects Directory',
+      description: 'Where Conduit scans for local git projects',
+      value: 'Not set',
+    },
+    {
+      id: 'default_model',
+      title: 'Default Model',
+      description: 'Agent + model used for new sessions',
+      value: 'Codex: GPT-5.4',
+    },
+    {
+      id: 'enabled_providers',
+      title: 'Enabled Providers',
+      description: 'Providers shown in model selection',
+      value: 'Claude, Codex, Gemini, OpenCode, Pi',
+    },
+    {
+      id: 'theme',
+      title: 'Theme',
+      description: 'Active color theme',
+      value: theme.displayName,
+    },
+    {
+      id: 'workspace_defaults',
+      title: 'Workspace Defaults',
+      description: 'Defaults applied when a repo has no override',
+      value: 'worktree, delete branch on, remote prompt on',
+    },
+  ],
+};
+
+export const modelsResponse: ListModelsResponse = {
+  groups: [
+    {
+      agent_type: 'pi',
+      section_title: 'Pi',
+      icon: 'π',
+      models: [
+        {
+          id: 'anthropic/claude-haiku-4-5',
+          display_name: 'anthropic/claude-haiku-4-5',
+          description: 'Pi model from anthropic',
+          is_default: true,
+          agent_type: 'pi',
+          context_window: 200000,
+        },
+      ],
+    },
+  ],
+};
+
 function fulfillJson(route: Route, payload: unknown) {
   return route.fulfill({
     status: 200,
@@ -329,6 +384,8 @@ export async function mockApi(
     uiState?: UiState;
     queueMessages?: QueuedMessage[];
     sessionEvents?: typeof sessionEventsResponse;
+    settings?: typeof settingsResponse;
+    models?: ListModelsResponse;
   } = {}
 ) {
   const effectiveSession = overrides.session ?? session;
@@ -339,6 +396,8 @@ export async function mockApi(
   };
   const queueMessages = overrides.queueMessages ?? [];
   const effectiveSessionEvents = overrides.sessionEvents ?? sessionEventsResponse;
+  const effectiveSettings = overrides.settings ?? settingsResponse;
+  const effectiveModels = overrides.models ?? modelsResponse;
   let currentTheme = theme;
 
   await page.route('**/api/**', async (route) => {
@@ -422,8 +481,16 @@ export async function mockApi(
       return fulfillJson(route, currentTheme);
     }
 
+    if (path === '/settings') {
+      return fulfillJson(route, effectiveSettings);
+    }
+
     if (path === '/models') {
-      return fulfillJson(route, { groups: [] });
+      return fulfillJson(route, effectiveModels);
+    }
+
+    if (path === '/models/default') {
+      return route.fulfill({ status: 204, body: '' });
     }
 
     return fulfillJson(route, {});

--- a/web/tests/e2e/pi-agent-label.spec.ts
+++ b/web/tests/e2e/pi-agent-label.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test';
+import { installMockWebSocket } from './websocket-mock';
+import { mockApi, session } from './fixtures';
+
+const piSession = {
+  ...session,
+  agent_type: 'pi' as const,
+  title: 'Identify current AI model',
+  model: 'anthropic/claude-haiku-4-5',
+  model_display_name: 'anthropic/claude-haiku-4-5',
+};
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page, { session: piSession });
+  await installMockWebSocket(page);
+});
+
+test('renders Pi sessions with Pi agent labels instead of Gemini', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForResponse('**/api/bootstrap');
+  await expect(page.getByPlaceholder('Type a message...')).toBeVisible();
+
+  await expect(page.getByText('Pi · anthropic/claude-haiku-4-5')).toBeVisible();
+  await expect(page.getByText('anthropic/claude-haiku-4-5 · Pi')).toBeVisible();
+  await expect(page.getByText('anthropic/claude-haiku-4-5 Pi')).toBeVisible();
+  await expect(page.getByText('Gemini CLI')).toHaveCount(0);
+});

--- a/web/tests/e2e/pi-agent-label.spec.ts
+++ b/web/tests/e2e/pi-agent-label.spec.ts
@@ -20,8 +20,8 @@ test('renders Pi sessions with Pi agent labels instead of Gemini', async ({ page
   await page.waitForResponse('**/api/bootstrap');
   await expect(page.getByPlaceholder('Type a message...')).toBeVisible();
 
-  await expect(page.getByText('Pi · anthropic/claude-haiku-4-5')).toBeVisible();
+  await expect(page.getByRole('banner').getByText('Pi', { exact: true })).toBeVisible();
+  await expect(page.getByText('· anthropic/claude-haiku-4-5')).toBeVisible();
   await expect(page.getByText('anthropic/claude-haiku-4-5 · Pi')).toBeVisible();
-  await expect(page.getByText('anthropic/claude-haiku-4-5 Pi')).toBeVisible();
   await expect(page.getByText('Gemini CLI')).toHaveCount(0);
 });

--- a/web/tests/e2e/settings-default-model.spec.ts
+++ b/web/tests/e2e/settings-default-model.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+import { installMockWebSocket } from './websocket-mock';
+import { mockApi, session } from './fixtures';
+
+const busyPiSession = {
+  ...session,
+  agent_type: 'pi' as const,
+  model: 'anthropic/claude-haiku-4-5',
+  model_display_name: 'anthropic/claude-haiku-4-5',
+  agent_session_id: 'pi-live-session',
+  title: 'Busy Pi session',
+};
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page, { session: busyPiSession });
+  await installMockWebSocket(page);
+});
+
+test('settings can open default model picker even when the active session model is locked', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForResponse('**/api/bootstrap');
+  await expect(page.getByPlaceholder('Type a message...')).toBeVisible();
+
+  await page.getByLabel('Settings').click();
+  await expect(page.getByRole('heading', { name: 'Settings' })).toBeVisible();
+
+  await page.getByRole('button', { name: /Default Model/i }).click();
+
+  await expect(page.getByRole('heading', { name: 'Default Model' })).toBeVisible();
+  await expect(
+    page.getByRole('button', { name: /anthropic\/claude-haiku-4-5/i })
+  ).toBeVisible();
+  await expect(
+    page.getByText('Wait for the current response to finish before changing the model.')
+  ).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary

This PR properly integrates **Pi** as a first-class provider in Conduit across model discovery, session defaults, and the web UI.

### Pi model discovery
- discover available Pi models from `pi --list-models`
- read Pi's current model from RPC `get_state`
- stop showing a fake `Pi Default` entry in the model catalog
- refresh the Pi model registry from live CLI data during core initialization
- keep `default` as a compatibility alias where needed

### Web UI support for Pi
- add Pi to shared web agent types/metadata
- render Pi correctly in headers, tabs, chat chrome, session import, and model selection
- prevent Pi sessions from falling back to Gemini labels

### Default model picker flow
- separate **Settings → Default Model** from **change current session model**
- allow the default-model picker to open even when the active session is busy/locked
- keep current sessions unchanged while updating saved defaults for future sessions

## Tests

- `cargo check --all`
- `cargo test --all`
- `cd web && npm run test:e2e -- pi-agent-label.spec.ts settings-default-model.spec.ts`

## Regression coverage added

- `web/tests/e2e/pi-agent-label.spec.ts`
- `web/tests/e2e/settings-default-model.spec.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Pi agent support with model discovery, configurable reasoning effort, and interactive session messaging.
  * Extended agent and model selectors to include Pi.
  * Added WebSocket API support for Pi reasoning effort control and follow-up messaging configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->