### PR TITLE
fix(tui): enable bracketed paste mode for multiline input

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use anyhow::anyhow;
 use chrono::Utc;
 use crossterm::{
-    event::{EnableMouseCapture, Event, EventStream, KeyCode, KeyModifiers, MouseEventKind},
+    event::{EnableBracketedPaste, EnableMouseCapture, Event, EventStream, KeyCode, KeyModifiers, MouseEventKind},
     execute,
     terminal::{enable_raw_mode, EnterAlternateScreen},
 };
@@ -972,7 +972,7 @@ impl App {
         // Create terminal guard AFTER enabling features - Drop will clean up on any exit path
         let mut guard = TerminalGuard::new(keyboard_enhancement_enabled);
 
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture, EnableBracketedPaste)?;
 
         let backend = CrosstermBackend::new(stdout);
         let mut terminal = Terminal::new(backend)?;
@@ -8600,7 +8600,7 @@ impl App {
     ) -> anyhow::Result<()> {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        execute!(stdout, EnterAlternateScreen, EnableMouseCapture, EnableBracketedPaste)?;
         terminal.clear()?;
         Ok(())
     }

--- a/src/ui/terminal_guard.rs
+++ b/src/ui/terminal_guard.rs
@@ -4,7 +4,7 @@
 //! when the application exits, whether normally, via early return, or panic.
 
 use crossterm::{
-    event::{DisableMouseCapture, PopKeyboardEnhancementFlags},
+    event::{DisableBracketedPaste, DisableMouseCapture, PopKeyboardEnhancementFlags},
     execute,
     terminal::{disable_raw_mode, LeaveAlternateScreen},
 };
@@ -66,7 +66,7 @@ impl TerminalGuard {
             }
         }
         disable_raw_mode()?;
-        execute!(stdout, LeaveAlternateScreen, DisableMouseCapture)?;
+        execute!(stdout, LeaveAlternateScreen, DisableMouseCapture, DisableBracketedPaste)?;
         stdout.flush()?;
         Ok(())
     }
@@ -103,7 +103,7 @@ pub fn install_panic_hook() {
         if let Err(e) = disable_raw_mode() {
             tracing::debug!(error = %e, "Failed to disable raw mode in panic hook");
         }
-        if let Err(e) = execute!(stdout, LeaveAlternateScreen, DisableMouseCapture) {
+        if let Err(e) = execute!(stdout, LeaveAlternateScreen, DisableMouseCapture, DisableBracketedPaste) {
             tracing::debug!(error = %e, "Failed to restore terminal screen in panic hook");
         }
         if let Err(e) = stdout.flush() {


### PR DESCRIPTION
## Summary
Without `EnableBracketedPaste`, pasted newlines arrive as individual Enter key events, causing each line of a multiline paste to be submitted as a separate message. With bracketed paste enabled, the terminal wraps paste content so crossterm delivers it as a single `Event::Paste(text)`, which the existing `handle_paste_input` path already handles correctly.

Also adds `DisableBracketedPaste` to `TerminalGuard` cleanup and the panic hook so the terminal is fully restored on exit.

## Test plan
- [x] `cargo check` passes
- [ ] `cargo test` passes
- [ ] Paste multiline text into the TUI input — should arrive as a single block, not submitted line-by-line