### PR TITLE
fix(tui): restore modal focus when exiting sidebar via Esc

### DIFF
--- a/src/ui/app/app_actions_sidebar.rs
+++ b/src/ui/app/app_actions_sidebar.rs
@@ -36,7 +36,13 @@ impl App {
             }
             Action::ExitSidebarMode => {
                 self.state.sidebar_state.set_focused(false);
-                self.state.input_mode = InputMode::Normal;
+                // If a confirmation dialog is active, return focus to it rather
+                // than dropping to Normal (which routes keys to the prompt input).
+                if self.state.confirmation_dialog_state.visible {
+                    self.state.input_mode = InputMode::Confirming;
+                } else {
+                    self.state.input_mode = InputMode::Normal;
+                }
             }
             Action::ExpandOrSelect => {
                 // Same as Confirm for sidebar


### PR DESCRIPTION
## Summary
When a confirmation dialog is active (e.g. archive remote-branch prompt) and the user presses Ctrl+T to focus the sidebar then Esc to return, `ExitSidebarMode` was unconditionally setting `input_mode` to `Normal`, routing keyboard input to the prompt instead of back to the dialog. Now it restores `InputMode::Confirming` when a dialog is visible.

## Test plan
- [x] `cargo check` passes
- [ ] `cargo test` passes
- [ ] Open a confirmation dialog → Ctrl+T to sidebar → Esc — dialog should regain focus