### PR TITLE
fix(tui): map InputMode::FileViewer to FooterContext::FileViewer

### DIFF
--- a/src/ui/components/global_footer.rs
+++ b/src/ui/components/global_footer.rs
@@ -37,6 +37,8 @@ impl FooterContext {
             ViewMode::Chat => {
                 if input_mode == InputMode::SidebarNavigation {
                     FooterContext::Sidebar
+                } else if input_mode == InputMode::FileViewer {
+                    FooterContext::FileViewer
                 } else {
                     FooterContext::Chat
                 }


### PR DESCRIPTION
## Summary
`FileViewer` tabs were falling through to `FooterContext::Chat` in `from_state`, showing chat key hints even though those bindings don't apply in the file viewer. Now the correct `file_viewer_hints` are shown instead.

## Test plan
- [x] `cargo check` passes
- [ ] `cargo test` passes
- [ ] Open a file in the file viewer — footer should show file viewer hints, not chat hints