### PR TITLE
fix(keys): rebind Option+Arrow to line scroll instead of user message jump

### DIFF
--- a/src/config/default_keys.rs
+++ b/src/config/default_keys.rs
@@ -183,8 +183,8 @@ pub fn default_keybindings() -> KeybindingConfig {
         KeyCombo::new(KeyCode::Esc, KeyModifiers::NONE),
         Action::ScrollToBottom,
     );
-    bind(chat, "M-<Up>", Action::ScrollPrevUserMessage);
-    bind(chat, "M-<Down>", Action::ScrollNextUserMessage);
+    bind(chat, "M-<Up>", Action::ScrollUp(1));
+    bind(chat, "M-<Down>", Action::ScrollDown(1));
 
     // Tab toggles Plan/Build mode
     chat.insert(


### PR DESCRIPTION
## Summary
`M-<Up>` and `M-<Down>` were bound to `ScrollPrevUserMessage`/`ScrollNextUserMessage`, causing unexpected jumps between user messages. On macOS, `Ctrl+Arrow` is a system hotkey, so `Option+Arrow` is the natural choice for 1-line scrolling. This rebinds `M-<Up>`/`M-<Down>` to `ScrollUp`/`ScrollDown` for line-by-line scrolling.

## Test plan
- [x] `cargo check` passes
- [ ] `cargo test` passes
- [ ] Press Option+Up/Down in the TUI — should scroll one line at a time, not jump between user messages