### PR TITLE
add scrolling speed config option

### DIFF
--- a/src/config/config.toml.example
+++ b/src/config/config.toml.example
@@ -88,6 +88,8 @@
 # [ui]
 # # Show a minimal scrollbar in the chat view (default: false)
 # show_chat_scrollbar = false
+# # Lines scrolled per mouse-wheel tick in content views (default: 3)
+# mouse_scroll_lines = 3
 #
 # ============================================================================
 # Web Workspace Status

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -124,6 +124,8 @@ pub struct SelectionConfig {
 #[derive(Debug, Clone, Copy)]
 pub struct UiConfig {
     pub show_chat_scrollbar: bool,
+    /// Number of lines to scroll per mouse-wheel tick in content views
+    pub mouse_scroll_lines: usize,
 }
 
 #[derive(Debug, Clone, Default, Deserialize)]
@@ -135,6 +137,7 @@ pub struct TomlSelectionConfig {
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct TomlUiConfig {
     pub show_chat_scrollbar: Option<bool>,
+    pub mouse_scroll_lines: Option<usize>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -219,6 +222,7 @@ impl Default for Config {
             },
             ui: UiConfig {
                 show_chat_scrollbar: false,
+                mouse_scroll_lines: 3,
             },
             web_status: WebStatusConfig {
                 initial_scan: true,
@@ -715,6 +719,9 @@ impl Config {
                     if let Some(ui) = toml_config.ui {
                         if let Some(show_chat_scrollbar) = ui.show_chat_scrollbar {
                             config.ui.show_chat_scrollbar = show_chat_scrollbar;
+                        }
+                        if let Some(mouse_scroll_lines) = ui.mouse_scroll_lines {
+                            config.ui.mouse_scroll_lines = mouse_scroll_lines.max(1);
                         }
                     }
                     // Load web status configuration

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -11433,6 +11433,8 @@ mod tests {
         app.state.tab_manager.open_file(path).expect("open file");
         app.sync_input_mode_for_active_tab();
 
+        // Each wheel tick scrolls `mouse_scroll_lines` lines in content views.
+        let step = app.config().ui.mouse_scroll_lines;
         let mut pending_up = 0usize;
         let mut pending_down = 4usize;
         app.flush_scroll_deltas(&mut pending_up, &mut pending_down);
@@ -11445,7 +11447,7 @@ mod tests {
                 .active_file_viewer()
                 .expect("file viewer missing")
                 .scroll_offset,
-            4
+            4 * step
         );
     }
 

--- a/src/ui/app/app_input.rs
+++ b/src/ui/app/app_input.rs
@@ -722,6 +722,8 @@ impl App {
         let x = mouse.column;
         let y = mouse.row;
 
+        let scroll_step = self.config().ui.mouse_scroll_lines.max(1);
+
         match mouse.kind {
             MouseEventKind::ScrollUp => {
                 // Route scroll to appropriate component based on mode
@@ -754,20 +756,20 @@ impl App {
                 } else if self.handle_tab_bar_wheel(x, y, true) {
                     return Ok(Vec::new());
                 } else if let Some(file_session) = self.state.tab_manager.active_file_viewer_mut() {
-                    file_session.scroll_up(1);
-                    self.record_scroll(1);
+                    file_session.scroll_up(scroll_step);
+                    self.record_scroll(scroll_step);
                 } else if self.state.view_mode == ViewMode::RawEvents {
                     if let Some(session) = self.state.tab_manager.active_session_mut() {
                         if session.raw_events_view.is_detail_visible() {
-                            session.raw_events_view.event_detail.scroll_up(3);
+                            session.raw_events_view.event_detail.scroll_up(scroll_step);
                         } else {
-                            session.raw_events_view.scroll_up(3);
+                            session.raw_events_view.scroll_up(scroll_step);
                         }
                     }
-                    self.record_scroll(3);
+                    self.record_scroll(scroll_step);
                 } else if let Some(session) = self.state.tab_manager.active_session_mut() {
-                    session.chat_view.scroll_up(1);
-                    self.record_scroll(1);
+                    session.chat_view.scroll_up(scroll_step);
+                    self.record_scroll(scroll_step);
                 }
                 Ok(Vec::new())
             }
@@ -802,8 +804,8 @@ impl App {
                 } else if self.handle_tab_bar_wheel(x, y, false) {
                     return Ok(Vec::new());
                 } else if let Some(file_session) = self.state.tab_manager.active_file_viewer_mut() {
-                    file_session.scroll_down(1);
-                    self.record_scroll(1);
+                    file_session.scroll_down(scroll_step);
+                    self.record_scroll(scroll_step);
                 } else if self.state.view_mode == ViewMode::RawEvents {
                     let list_height = self.raw_events_list_visible_height();
                     let detail_height = self.raw_events_detail_visible_height();
@@ -811,18 +813,18 @@ impl App {
                         if session.raw_events_view.is_detail_visible() {
                             let content_height = session.raw_events_view.detail_content_height();
                             session.raw_events_view.event_detail.scroll_down(
-                                3,
+                                scroll_step,
                                 content_height,
                                 detail_height,
                             );
                         } else {
-                            session.raw_events_view.scroll_down(3, list_height);
+                            session.raw_events_view.scroll_down(scroll_step, list_height);
                         }
                     }
-                    self.record_scroll(3);
+                    self.record_scroll(scroll_step);
                 } else if let Some(session) = self.state.tab_manager.active_session_mut() {
-                    session.chat_view.scroll_down(1);
-                    self.record_scroll(1);
+                    session.chat_view.scroll_down(scroll_step);
+                    self.record_scroll(scroll_step);
                 }
                 Ok(Vec::new())
             }

--- a/src/ui/app/app_scroll.rs
+++ b/src/ui/app/app_scroll.rs
@@ -61,13 +61,19 @@ impl App {
             return;
         }
 
+        // Content views scroll multiple lines per wheel tick; menu selectors move
+        // one entry per tick regardless of this factor.
+        let step = self.config().ui.mouse_scroll_lines.max(1);
+        let up_lines = pending_up.saturating_mul(step);
+        let down_lines = pending_down.saturating_mul(step);
+
         if self.state.input_mode == InputMode::ShowingHelp {
             // Route scroll to help dialog
-            if *pending_up > 0 {
-                self.state.help_dialog_state.scroll_up(*pending_up);
+            if up_lines > 0 {
+                self.state.help_dialog_state.scroll_up(up_lines);
             }
-            if *pending_down > 0 {
-                self.state.help_dialog_state.scroll_down(*pending_down);
+            if down_lines > 0 {
+                self.state.help_dialog_state.scroll_down(down_lines);
             }
         } else if self.state.input_mode == InputMode::PickingProject
             && self.state.project_picker_state.is_visible()
@@ -158,11 +164,11 @@ impl App {
                 .unwrap_or(20)
                 .max(1);
             if let Some(file_session) = self.state.tab_manager.active_file_viewer_mut() {
-                if *pending_up > 0 {
-                    file_session.scroll_up(*pending_up);
+                if up_lines > 0 {
+                    file_session.scroll_up(up_lines);
                 }
-                if *pending_down > 0 {
-                    file_session.scroll_down_clamped(*pending_down, visible_height);
+                if down_lines > 0 {
+                    file_session.scroll_down_clamped(down_lines, visible_height);
                 }
             }
         } else if self.state.view_mode == ViewMode::RawEvents {
@@ -172,33 +178,31 @@ impl App {
                 if session.raw_events_view.is_detail_visible() {
                     let content_height = session.raw_events_view.detail_content_height();
                     let visible_height = detail_height;
-                    if *pending_up > 0 {
-                        session.raw_events_view.event_detail.scroll_up(*pending_up);
+                    if up_lines > 0 {
+                        session.raw_events_view.event_detail.scroll_up(up_lines);
                     }
-                    if *pending_down > 0 {
+                    if down_lines > 0 {
                         session.raw_events_view.event_detail.scroll_down(
-                            *pending_down,
+                            down_lines,
                             content_height,
                             visible_height,
                         );
                     }
                 } else {
-                    if *pending_up > 0 {
-                        session.raw_events_view.scroll_up(*pending_up);
+                    if up_lines > 0 {
+                        session.raw_events_view.scroll_up(up_lines);
                     }
-                    if *pending_down > 0 {
-                        session
-                            .raw_events_view
-                            .scroll_down(*pending_down, list_height);
+                    if down_lines > 0 {
+                        session.raw_events_view.scroll_down(down_lines, list_height);
                     }
                 }
             }
         } else if let Some(session) = self.state.tab_manager.active_session_mut() {
-            if *pending_up > 0 {
-                session.chat_view.scroll_up(*pending_up);
+            if up_lines > 0 {
+                session.chat_view.scroll_up(up_lines);
             }
-            if *pending_down > 0 {
-                session.chat_view.scroll_down(*pending_down);
+            if down_lines > 0 {
+                session.chat_view.scroll_down(down_lines);
             }
         }
 


### PR DESCRIPTION
## Summary

scrolling in conduit is pretty slow compared to claude-code and similar tools.

I've added a config option that allows configuring this
(and bumped the default to 3 lines / scroll event)

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement


## Testing

Describe the tests you ran to verify your changes:

- [x] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
(not on nightly cargo but no new issues are added by this commit)

- [x] `cargo fmt --check` passes
- [x] Manual testing performed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

