### PR TITLE
Fix pastes

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -10,7 +10,10 @@ use std::time::{Duration, Instant};
 use anyhow::anyhow;
 use chrono::Utc;
 use crossterm::{
-    event::{EnableMouseCapture, Event, EventStream, KeyCode, KeyModifiers, MouseEventKind},
+    event::{
+        EnableBracketedPaste, EnableMouseCapture, Event, EventStream, KeyCode, KeyModifiers,
+        MouseEventKind,
+    },
     execute,
     terminal::{enable_raw_mode, EnterAlternateScreen},
 };
@@ -972,7 +975,12 @@ impl App {
         // Create terminal guard AFTER enabling features - Drop will clean up on any exit path
         let mut guard = TerminalGuard::new(keyboard_enhancement_enabled);
 
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        execute!(
+            stdout,
+            EnterAlternateScreen,
+            EnableMouseCapture,
+            EnableBracketedPaste
+        )?;
 
         let backend = CrosstermBackend::new(stdout);
         let mut terminal = Terminal::new(backend)?;
@@ -8600,7 +8608,12 @@ impl App {
     ) -> anyhow::Result<()> {
         enable_raw_mode()?;
         let mut stdout = io::stdout();
-        execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
+        execute!(
+            stdout,
+            EnterAlternateScreen,
+            EnableMouseCapture,
+            EnableBracketedPaste
+        )?;
         terminal.clear()?;
         Ok(())
     }

--- a/src/ui/terminal_guard.rs
+++ b/src/ui/terminal_guard.rs
@@ -4,7 +4,7 @@
 //! when the application exits, whether normally, via early return, or panic.
 
 use crossterm::{
-    event::{DisableMouseCapture, PopKeyboardEnhancementFlags},
+    event::{DisableBracketedPaste, DisableMouseCapture, PopKeyboardEnhancementFlags},
     execute,
     terminal::{disable_raw_mode, LeaveAlternateScreen},
 };
@@ -66,7 +66,12 @@ impl TerminalGuard {
             }
         }
         disable_raw_mode()?;
-        execute!(stdout, LeaveAlternateScreen, DisableMouseCapture)?;
+        execute!(
+            stdout,
+            LeaveAlternateScreen,
+            DisableMouseCapture,
+            DisableBracketedPaste
+        )?;
         stdout.flush()?;
         Ok(())
     }
@@ -103,7 +108,12 @@ pub fn install_panic_hook() {
         if let Err(e) = disable_raw_mode() {
             tracing::debug!(error = %e, "Failed to disable raw mode in panic hook");
         }
-        if let Err(e) = execute!(stdout, LeaveAlternateScreen, DisableMouseCapture) {
+        if let Err(e) = execute!(
+            stdout,
+            LeaveAlternateScreen,
+            DisableMouseCapture,
+            DisableBracketedPaste
+        ) {
             tracing::debug!(error = %e, "Failed to restore terminal screen in panic hook");
         }
         if let Err(e) = stdout.flush() {


### PR DESCRIPTION
## Summary

Pasting content with multiple newlines will currently queue
all the changes every newline. Then you have to hold `Esc` to actually send all of the content.

This change fixes pastes to work properly.

## Related Issues

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing

Describe the tests you ran to verify your changes:

- [x] `cargo test` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes
- [x] Manual testing performed

### Test Details
## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
