### PR TITLE
test: fix test with race condition

### DIFF
--- a/src/ui/components/source_highlighter.rs
+++ b/src/ui/components/source_highlighter.rs
@@ -556,7 +556,7 @@ mod tests {
     use super::*;
     use crate::ui::components::{set_theme, Theme};
 
-    struct ThemeReset(Theme);
+    struct ThemeReset(Theme, #[allow(dead_code)] parking_lot::MutexGuard<'static, ()>);
 
     impl Drop for ThemeReset {
         fn drop(&mut self) {
@@ -565,7 +565,9 @@ mod tests {
     }
 
     fn preserve_theme() -> ThemeReset {
-        ThemeReset(current_theme().clone())
+        // Hold the shared guard so theme-mutating tests don't race on global state.
+        let guard = crate::ui::components::theme::THEME_TEST_GUARD.lock();
+        ThemeReset(current_theme().clone(), guard)
     }
 
     #[test]

--- a/src/ui/components/theme/mod.rs
+++ b/src/ui/components/theme/mod.rs
@@ -51,6 +51,15 @@ static THEME_REVISION: AtomicU64 = AtomicU64::new(0);
 /// Global theme registry for discovery.
 static REGISTRY: OnceLock<RwLock<ThemeRegistry>> = OnceLock::new();
 
+/// Serializes tests that mutate the process-global theme.
+///
+/// The current theme is shared across the whole process, so tests that call
+/// [`set_theme`] and then observe [`current_theme`] must run one at a time or
+/// they race on each other's writes. Every theme-mutating test acquires this
+/// guard for its duration via its module's `preserve_theme` helper.
+#[cfg(test)]
+pub static THEME_TEST_GUARD: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
 fn theme_lock() -> &'static RwLock<Theme> {
     THEME.get_or_init(|| RwLock::new(Theme::default()))
 }

--- a/src/ui/components/theme_picker.rs
+++ b/src/ui/components/theme_picker.rs
@@ -929,7 +929,7 @@ mod tests {
     use super::*;
     use crate::ui::components::{current_theme_name, set_theme, Theme};
 
-    struct ThemeReset(Theme);
+    struct ThemeReset(Theme, #[allow(dead_code)] parking_lot::MutexGuard<'static, ()>);
 
     impl Drop for ThemeReset {
         fn drop(&mut self) {
@@ -938,7 +938,9 @@ mod tests {
     }
 
     fn preserve_theme() -> ThemeReset {
-        ThemeReset(crate::ui::components::current_theme().clone())
+        // Hold the shared guard so theme-mutating tests don't race on global state.
+        let guard = crate::ui::components::theme::THEME_TEST_GUARD.lock();
+        ThemeReset(crate::ui::components::current_theme().clone(), guard)
     }
 
     #[test]

--- a/src/web/handlers/themes.rs
+++ b/src/web/handlers/themes.rs
@@ -360,7 +360,7 @@ mod tests {
     use super::*;
     use crate::ui::components::theme::{set_theme, Theme};
 
-    struct ThemeReset(Theme);
+    struct ThemeReset(Theme, #[allow(dead_code)] parking_lot::MutexGuard<'static, ()>);
 
     impl Drop for ThemeReset {
         fn drop(&mut self) {
@@ -369,7 +369,9 @@ mod tests {
     }
 
     fn preserve_theme() -> ThemeReset {
-        ThemeReset(current_theme().clone())
+        // Hold the shared guard so theme-mutating tests don't race on global state.
+        let guard = crate::ui::components::theme::THEME_TEST_GUARD.lock();
+        ThemeReset(current_theme().clone(), guard)
     }
 
     #[tokio::test]


### PR DESCRIPTION
The current theme is process-global (static RwLock<Theme>), so tests across theme_picker, source_highlighter, and web/handlers/themes that call set_theme() and then assert on the theme raced under cargo's parallel test runner — theme_preview_keeps_checkmark_on_confirmed_theme failed intermittently when a concurrent test reset the global state mid-assertion.

Add a shared THEME_TEST_GUARD mutex that every theme-mutating test holds for its duration via preserve_theme(), so they run one at a time. parking_lot mutexes don't poison on panic, so a failing test can't deadlock the others. The guard field is #[allow(dead_code)] since it is held purely for its RAII drop.

## Related Issues

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement

## Testing

Describe the tests you ran to verify your changes:

- [ ] `cargo test` passes
- [ ] `cargo clippy -- -D warnings` passes
- [ ] `cargo fmt --check` passes
- [ ] Manual testing performed

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes

